### PR TITLE
fix: Force push to gh-pages to handle concurrent updates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -691,8 +691,8 @@ jobs:
           REF_NAME="${{ needs.prepare.outputs.target_ref }}"
           git commit -m "Update benchmark data and reports for $REF_NAME" || echo "No changes to commit"
 
-          # Push
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
+          # Push (force to handle concurrent gh-pages updates from docs workflow)
+          git push --force https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} gh-pages
 
           echo "✅ Pushed to gh-pages"
         continue-on-error: true

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -29,6 +29,6 @@ jobs:
           source .venv/bin/activate
           pip install polars-bio
       - name: Deploy docs
-        run: poetry run mkdocs gh-deploy --remote-branch gh-pages -f mkdocs.yml
+        run: poetry run mkdocs gh-deploy --force --remote-branch gh-pages -f mkdocs.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Both the docs and benchmark workflows push to gh-pages branch. When they run concurrently (e.g., on tag push), one can fail with "rejected - fetch first" error. Adding --force flag resolves this since gh-pages contains only generated content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)