### PR TITLE
fix: Move mkdocs-glightbox to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
   "datafusion (>=50.0.0,<51)",
   "tqdm (>=4.67.0,<5)",
   "typing-extensions (>=4.14.0,<5)",
-  "mkdocs-glightbox (>=0.5.1,<1)",
   "polars-config-meta (>=0.3.0,<1)"
 ]
 


### PR DESCRIPTION
## Summary
- Removes `mkdocs-glightbox` from runtime dependencies in `[project] dependencies`
- Keeps it in `[tool.poetry.dev-dependencies]` where it belongs

## Rationale
`mkdocs-glightbox` is a MkDocs plugin that adds image lightbox functionality to documentation. It's only needed when building/serving documentation, not for polars-bio's runtime functionality.

Currently, it was incorrectly listed in both:
- Regular dependencies (line 22) - ❌ wrong
- Dev dependencies (line 83) - ✅ correct

All other MkDocs-related packages (`mkdocs`, `mkdocs-material`, `mkdocs-jupyter`, etc.) are correctly placed only in dev dependencies.

## Changes
- Removed `mkdocs-glightbox (>=0.5.1,<1)` from `[project] dependencies` section

## Test plan
- [ ] Verify the package still builds correctly
- [ ] Verify documentation builds correctly with dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)