### PR TITLE
chore: Preparing release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2025-02-12
+
+### Added
+- Pairs (Hi-C) format scan/read support (#290)
+  - `read_pairs()`, `scan_pairs()`, `register_pairs()` for reading Hi-C `.pairs` / `.pairs.gz` / `.pairs.bgz` files
+  - Tabix-indexed querying with predicate pushdown on chr1/pos1, residual filters on chr2/pos2
+  - Projection pushdown support
+- New `template_length` (TLEN) column for BAM/SAM/CRAM (#294)
+  - Non-nullable `Int32` column — schema grows from 11 to 12 core columns
+- Non-nullable `mapping_quality` (MAPQ) for BAM/SAM/CRAM (#294)
+  - Now `UInt32` — value 255 is preserved instead of becoming null
+- Non-nullable `name` (QNAME) for BAM/SAM/CRAM (#294)
+  - `*` is preserved as a string value instead of becoming null
+
+### Changed
+- Bumped datafusion-bio-formats to 0.3.0 (#292)
+
 ## [0.21.0] - 2025-02-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [lib]

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -101,7 +101,7 @@ merge = range_operations.merge
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.21.0"
+version = "0.22.0"
 description = "Blazing fast genomic operations on large Python dataframes"
 authors = []
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version to 0.22.0 in `Cargo.toml` and `pyproject.toml`
- Update `CHANGELOG.md` with changes since 0.21.0:
  - Pairs (Hi-C) format scan/read support (#290)
  - New `template_length` (TLEN) column, non-nullable MAPQ/QNAME for BAM/SAM/CRAM (#294)
  - Bumped datafusion-bio-formats to 0.3.0 (#292)

## Test plan
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)