### PR TITLE
chore: Bump datafusion-bio-formats to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,8 +1195,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1245,8 +1245,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1267,8 +1267,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1293,8 +1293,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1315,8 +1315,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1340,8 +1340,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1369,8 +1369,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1397,8 +1397,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=67a43413258d6228f801e28fc879284231eda50a#67a43413258d6228f801e28fc879284231eda50a"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=937be71169a6f97d8a787320c8a40cd844836d9a#937be71169a6f97d8a787320c8a40cd844836d9a"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -2274,7 +2274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3416,6 +3416,7 @@ dependencies = [
  "crossbeam-channel",
  "flate2",
  "futures",
+ "libdeflater",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -3430,6 +3431,7 @@ dependencies = [
  "crossbeam-channel",
  "flate2",
  "futures",
+ "libdeflater",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -3790,7 +3792,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4211,7 +4213,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polars_bio"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4833,7 +4835,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5398,7 +5400,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5991,7 +5993,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "67a43413258d6228f801e28fc879284231eda50a" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "937be71169a6f97d8a787320c8a40cd844836d9a" }
 
 
 async-trait = "0.1.86"


### PR DESCRIPTION
## Summary
- Bumps `datafusion-bio-formats` from 0.3.0 to 0.4.0 (upstream PR [#67](https://github.com/biodatageeks/datafusion-bio-formats/pull/67), [#68](https://github.com/biodatageeks/datafusion-bio-formats/pull/68), [#69](https://github.com/biodatageeks/datafusion-bio-formats/pull/69))

### VCF optimizations (PR #67, #68)
- Eliminate per-record heap allocation and clone in VCF INFO field processing
- Zero-copy Arrow array construction (removes `.to_vec()` copies per batch)
- Enable `libdeflate` on all noodles-bgzf dependencies (~30-50% faster BGZF decompression for VCF, BAM, GFF, and Pairs)
- Early residual filter evaluation before accumulation in non-indexed VCF paths
- Reusable buffer for multi-value field joining (eliminates intermediate Vec allocations)
- Replace `panic!` with proper `ArrowError` for unsupported INFO field types

### FASTQ optimizations (PR #69)
- Replace `Vec<String>` accumulation with `StringBuilder` in sequential/remote code paths — eliminates 4x per-record heap allocations
- Fix backpressure spin-loop in threaded path: recover batch via `into_inner()` instead of cloning `RecordBatch`
- Net result: **-107 lines** in FASTQ crate

## Test plan
- [ ] `cargo check` passes
- [ ] `maturin develop --release` builds successfully
- [ ] All IO tests pass (`pytest tests/test_io_*.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)