### PR TITLE
fix: Handle missing value in VCF INFO array fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "0.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d#4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc446f3577804f2ef9602f43c315711fcc52466#5fc446f3577804f2ef9602f43c315711fcc52466"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1428,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-pileup"
 version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=0de60bdf5817400b7c926f5ddf6b99c6930a182d#0de60bdf5817400b7c926f5ddf6b99c6930a182d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=9ef64a1f16bedf4096ae37a0b332ce15f3a18255#9ef64a1f16bedf4096ae37a0b332ce15f3a18255"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-ranges"
 version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=0de60bdf5817400b7c926f5ddf6b99c6930a182d#0de60bdf5817400b7c926f5ddf6b99c6930a182d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=9ef64a1f16bedf4096ae37a0b332ce15f3a18255#9ef64a1f16bedf4096ae37a0b332ce15f3a18255"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5382,7 +5382,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "superintervals"
 version = "0.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=0de60bdf5817400b7c926f5ddf6b99c6930a182d#0de60bdf5817400b7c926f5ddf6b99c6930a182d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=9ef64a1f16bedf4096ae37a0b332ce15f3a18255#9ef64a1f16bedf4096ae37a0b332ce15f3a18255"
 dependencies = [
  "aligned-vec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4ba1ca3e108a5edc5d31d03bacbe04f2ddf0b64d" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc446f3577804f2ef9602f43c315711fcc52466" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }

--- a/tests/data/io/vcf/info_missing_array.vcf
+++ b/tests/data/io/vcf/info_missing_array.vcf
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.3
+##INFO=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for ref and alt alleles">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency">
+##INFO=<ID=ALLELE_ID,Number=.,Type=String,Description="Allele identifiers">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	100	rs1	A	T	60	PASS	AD=.,15;AF=0.5;ALLELE_ID=.,alt1
+chr1	200	rs2	G	C,T	80	PASS	AD=10,.,5;AF=.,0.3;ALLELE_ID=ref2,.,alt2
+chr1	300	rs3	C	T,A	70	PASS	AD=5,.,10;AF=0.3,.;ALLELE_ID=ref3,alt3a,.
+chr1	400	rs4	T	G	90	PASS	AD=20,30;AF=0.6;ALLELE_ID=ref4,alt4

--- a/tests/test_vcf_info_missing_values.py
+++ b/tests/test_vcf_info_missing_values.py
@@ -1,0 +1,104 @@
+"""Test VCF INFO array fields with missing values (`.`).
+
+Regression test for https://github.com/biodatageeks/datafusion-bio-formats/pull/74
+and https://github.com/biodatageeks/polars-bio/issues/312.
+
+VCF INFO array fields (Number=R, Number=A, Number=.) can contain `.` as the
+standard missing value within comma-separated elements (e.g. AD=.,15 or AF=0.5,.).
+Previously this caused a panic and silent data truncation.
+"""
+
+import polars_bio as pb
+
+VCF_PATH = "tests/data/io/vcf/info_missing_array.vcf"
+
+
+def test_info_array_missing_values_no_row_loss():
+    """All 4 rows must be returned — missing '.' must not cause silent data loss."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["AD", "AF", "ALLELE_ID"])
+    assert (
+        len(df) == 4
+    ), f"Expected 4 rows, got {len(df)} — missing value caused row loss"
+
+
+def test_info_array_missing_integer():
+    """AD (Number=R, Type=Integer) with '.' elements → null in list."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["AD"])
+
+    # Row 0: AD=.,15 → [null, 15]
+    ad0 = df["AD"][0].to_list()
+    assert len(ad0) == 2
+    assert ad0[0] is None
+    assert ad0[1] == 15
+
+    # Row 1: AD=10,.,5 → [10, null, 5]
+    ad1 = df["AD"][1].to_list()
+    assert len(ad1) == 3
+    assert ad1[0] == 10
+    assert ad1[1] is None
+    assert ad1[2] == 5
+
+    # Row 3: AD=20,30 → [20, 30] (no missing — still works)
+    ad3 = df["AD"][3].to_list()
+    assert ad3 == [20, 30]
+
+
+def test_info_array_missing_float():
+    """AF (Number=A, Type=Float) with '.' elements → null in list."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["AF"])
+
+    # Row 0: AF=0.5 → [0.5]
+    af0 = df["AF"][0].to_list()
+    assert len(af0) == 1
+    assert abs(af0[0] - 0.5) < 1e-6
+
+    # Row 1: AF=.,0.3 → [null, 0.3]
+    af1 = df["AF"][1].to_list()
+    assert len(af1) == 2
+    assert af1[0] is None
+    assert abs(af1[1] - 0.3) < 1e-6
+
+    # Row 2: AF=0.3,. → [0.3, null]
+    af2 = df["AF"][2].to_list()
+    assert len(af2) == 2
+    assert abs(af2[0] - 0.3) < 1e-6
+    assert af2[1] is None
+
+
+def test_info_array_missing_string():
+    """ALLELE_ID (Number=., Type=String) with '.' elements → null in list."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["ALLELE_ID"])
+
+    # Row 0: ALLELE_ID=.,alt1 → [null, "alt1"]
+    aid0 = df["ALLELE_ID"][0].to_list()
+    assert len(aid0) == 2
+    assert aid0[0] is None
+    assert aid0[1] == "alt1"
+
+    # Row 1: ALLELE_ID=ref2,.,alt2 → ["ref2", null, "alt2"]
+    aid1 = df["ALLELE_ID"][1].to_list()
+    assert len(aid1) == 3
+    assert aid1[0] == "ref2"
+    assert aid1[1] is None
+    assert aid1[2] == "alt2"
+
+    # Row 2: ALLELE_ID=ref3,alt3a,. → ["ref3", "alt3a", null]
+    aid2 = df["ALLELE_ID"][2].to_list()
+    assert len(aid2) == 3
+    assert aid2[0] == "ref3"
+    assert aid2[1] == "alt3a"
+    assert aid2[2] is None
+
+    # Row 3: ALLELE_ID=ref4,alt4 → ["ref4", "alt4"] (no missing)
+    aid3 = df["ALLELE_ID"][3].to_list()
+    assert aid3 == ["ref4", "alt4"]
+
+
+def test_scan_vcf_info_array_missing_values():
+    """Lazy scan should also handle missing INFO array values."""
+    lf = pb.scan_vcf(VCF_PATH, info_fields=["AD", "AF", "ALLELE_ID"])
+    df = lf.collect()
+    assert len(df) == 4
+    assert "AD" in df.columns
+    assert "AF" in df.columns
+    assert "ALLELE_ID" in df.columns


### PR DESCRIPTION
## Summary

- Bump `datafusion-bio-formats` git rev to pick up the fix from [datafusion-bio-formats#74](https://github.com/biodatageeks/datafusion-bio-formats/pull/74)
- VCF INFO array fields (`Number=R`, `Number=A`, `Number=.`) panicked on `.` (the standard VCF missing value) within comma-separated elements (e.g. `AD=.,15`, `AF=0.5,.`), causing **silent data truncation** (e.g. 5M rows → 229K rows with no error)
- Add regression tests covering all 3 array types (Integer, Float, String) with missing values

Fixes #312

## Test plan

- [x] `test_info_array_missing_values_no_row_loss` — all 4 rows returned (no silent data loss)
- [x] `test_info_array_missing_integer` — `.` → `null` in integer list arrays
- [x] `test_info_array_missing_float` — `.` → `null` in float list arrays
- [x] `test_info_array_missing_string` — `.` → `null` in string list arrays
- [x] `test_scan_vcf_info_array_missing_values` — lazy scan path also works
- [x] All 34 existing VCF tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)