### PR TITLE
feat: Add cluster, complement, subtract to LazyFrame .pb namespace

### DIFF
--- a/polars_bio/polars_ext.py
+++ b/polars_bio/polars_ext.py
@@ -259,6 +259,67 @@ class PolarsRangesOperations:
             self._ldf, other_df, cols1=cols1, cols2=cols2, suffixes=suffixes
         )
 
+    def cluster(
+        self,
+        min_dist: int = 0,
+        cols: Union[list[str], None] = ["chrom", "start", "end"],
+    ) -> pl.LazyFrame:
+        """
+        !!! note
+            Alias for [cluster](api.md#polars_bio.cluster)
+
+        Note:
+            Coordinate system is determined from DataFrame metadata.
+            Set metadata using: `df.config_meta.set(coordinate_system_zero_based=True)`
+        """
+        return pb.cluster(
+            self._ldf,
+            min_dist=min_dist,
+            cols=cols,
+        )
+
+    def complement(
+        self,
+        view_df: Optional[pl.LazyFrame] = None,
+        cols: Union[list[str], None] = ["chrom", "start", "end"],
+        view_cols: Union[list[str], None] = None,
+    ) -> pl.LazyFrame:
+        """
+        !!! note
+            Alias for [complement](api.md#polars_bio.complement)
+
+        Note:
+            Coordinate system is determined from DataFrame metadata.
+            Set metadata using: `df.config_meta.set(coordinate_system_zero_based=True)`
+        """
+        return pb.complement(
+            self._ldf,
+            view_df=view_df,
+            cols=cols,
+            view_cols=view_cols,
+        )
+
+    def subtract(
+        self,
+        other_df: pl.LazyFrame,
+        cols1: Union[list[str], None] = ["chrom", "start", "end"],
+        cols2: Union[list[str], None] = ["chrom", "start", "end"],
+    ) -> pl.LazyFrame:
+        """
+        !!! note
+            Alias for [subtract](api.md#polars_bio.subtract)
+
+        Note:
+            Coordinate system is determined from DataFrame metadata.
+            Set metadata using: `df.config_meta.set(coordinate_system_zero_based=True)`
+        """
+        return pb.subtract(
+            self._ldf,
+            other_df,
+            cols1=cols1,
+            cols2=cols2,
+        )
+
     def sink_vcf(self, path: str) -> None:
         """
         Streaming write LazyFrame to VCF format.


### PR DESCRIPTION
## Summary
- Add `cluster`, `complement`, and `subtract` methods to the `PolarsRangesOperations` LazyFrame `.pb` namespace in `polars_ext.py`
- These range operations were introduced in #311 at the top-level `pb.*` API but were missing from the `lf.pb.*` Polars extension namespace

## Test plan
- [ ] Verify `lf.pb.cluster()`, `lf.pb.complement()`, `lf.pb.subtract()` delegate correctly to top-level functions
- [ ] Run existing range operation tests: `python -m pytest tests/ -k "cluster or complement or subtract" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)