### PR TITLE
fix: BAM indexed scan skips unmapped reads silently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "0.5.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=39fcff3#39fcff34ae49b49f19807b3ababa9fc93a27333f"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=79a33e2#79a33e2a45dbb5ec4ee493af1937e4a43ccf9859"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e63b6ba" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "79a33e2" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }


### PR DESCRIPTION
## Summary
- bump all `datafusion-bio-formats` dependencies to `79a33e2` in `Cargo.toml`
- refresh `Cargo.lock` to the same upstream commit
- add a BAM regression test for indexed files containing only no-coordinate (`RNAME=*`, `POS=0`) records

## Why
- validates the upstream fix path discussed in biodatageeks/datafusion-bio-formats#86 and downstream biodatageeks/polars-bio#330
- protects against regressions where indexed scans either dropped or errored on `n_no_coor`-only BAM input

## Validation
- `cargo check -p polars_bio`
- `python -m pytest tests/test_io_bam.py -k "indexed_no_coor_only_records" -q`
- manual smoke script: indexed/non-indexed no-coor-only + mixed BAM (all paths returned expected rows)
