### PR TITLE
fix: Update pypdf to 6.7.5 (security)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4532,14 +4532,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "6.7.1"
+version = "6.7.5"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pypdf-6.7.1-py3-none-any.whl", hash = "sha256:a02ccbb06463f7c334ce1612e91b3e68a8e827f3cee100b9941771e6066b094e"},
-    {file = "pypdf-6.7.1.tar.gz", hash = "sha256:6b7a63be5563a0a35d54c6d6b550d75c00b8ccf36384be96365355e296e6b3b0"},
+    {file = "pypdf-6.7.5-py3-none-any.whl", hash = "sha256:07ba7f1d6e6d9aa2a17f5452e320a84718d4ce863367f7ede2fd72280349ab13"},
+    {file = "pypdf-6.7.5.tar.gz", hash = "sha256:40bb2e2e872078655f12b9b89e2f900888bb505e88a82150b64f9f34fa25651d"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Summary

- Updates `pypdf` from 6.7.1 → 6.7.5 in `poetry.lock` to resolve 4 open Dependabot security alerts (#47-50)
- All are dev-only dependencies (via `mkdocs-with-pdf`), no runtime impact

### Resolved CVEs
| Alert | CVE | Severity | Description |
|-------|-----|----------|-------------|
| #50 | CVE-2026-28804 | medium | Inefficient ASCIIHexDecode decoding |
| #49 | CVE-2026-28351 | medium | RunLengthDecode RAM exhaustion |
| #48 | CVE-2026-27888 | medium | FlateDecode XFA RAM exhaustion |
| #47 | CVE-2026-27628 | low | Infinite loop in circular /Prev entries |

### Remaining open alert
- **#39 jsonwebtoken (CVE-2026-25537)** — transitive Rust dep via `opendal` → `reqsign`. Requires upstream update. Tracked in biodatageeks/datafusion-bio-formats#111

## Test plan
- [x] `poetry.lock` only changes pypdf version
- [ ] CI passes (dev dependency only, no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)