### PR TITLE
chore: Prepare 0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Bumped datafusion-bio-formats to 0.5.0 (#300)
-  - VCF parsing optimization: eliminate per-record clones, enable `libdeflater` for faster gzip decompression (upstream PR #67, #68)
-  - FASTQ sequential/remote parsing optimization: eliminate per-record allocations (upstream PR #69)
+## [0.26.0] - 2026-03-07
 
-### Removed
-- **BREAKING**: Removed `thread_num` parameter from `read_bed()`, `scan_bed()`, and `register_bed()`. Threading is now handled automatically by the upstream library. Simply remove the parameter from your calls.
+### Added
+- GTF format support with full read/scan/register pipeline (#336)
+  - `read_gtf()`, `scan_gtf()`, `register_gtf()` for reading GTF files
+  - Attribute flattening via `attr_fields` parameter
+  - Predicate pushdown and projection pushdown support
+  - Coordinate system support (0-based / 1-based)
+  - Compressed file support (gzip, bgzf)
+  - Object storage support (S3, GCS, Azure)
+- Auto-infer custom SAM tag types from file sampling (#335)
+  - New `infer_tag_types` parameter (default: True) for BAM/SAM/CRAM scan/read/describe/pileup
+  - New `infer_tag_sample_size` parameter to control sampling depth
+  - New `tag_type_hints` parameter for explicit type overrides (format: `["pt:i", "de:f"]`)
+  - Previously unknown tags defaulted to Utf8; now correctly inferred as Int32/Float32/etc.
+  - 26 nanopore-specific custom tags tested end-to-end
+
+### Fixed
+- **Critical**: Coalesce partitions before single-file writes (#338)
+  - When `target_partitions > 1`, data from partitions 1..N was silently dropped
+  - Affects VCF, BAM, CRAM, FASTQ write paths
+- Preserve contig metadata (##contig lines) in VCF write/sink output (#340)
+- Multisample VCF memory optimization (#331)
+- No-coordinate BAM regression test added (#332)
+
+### Security
+- Updated pypdf to 6.7.5 to resolve 4 CVEs (#341)
+
+### Changed
+- Deduplicated GffLazyFrameWrapper / GtfLazyFrameWrapper into shared AnnotationLazyFrameWrapper
+- Renamed `execute_streaming_write` to `execute_fastq_streaming_write`
+- Extracted shared `execute_write()` for all format writers
 
 ## [0.22.0] - 2025-02-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,7 +4267,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polars_bio"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 
 [lib]

--- a/docs/blog/posts/release-0.26.0.md
+++ b/docs/blog/posts/release-0.26.0.md
@@ -1,0 +1,113 @@
+---
+draft: false
+date:
+  created: 2026-03-07
+categories:
+  - releases
+
+---
+
+# polars-bio 0.26.0: GTF Support and Smart Tag Type Inference
+
+polars-bio 0.26.0 brings first-class [GTF](https://en.wikipedia.org/wiki/Gene_transfer_format) format support, automatic SAM tag type inference for custom/nanopore tags, and critical bug fixes for multi-partition writes and VCF contig metadata.
+
+<!-- more -->
+
+## GTF Format Support
+
+GTF (Gene Transfer Format) is now fully supported with `read_gtf()`, `scan_gtf()`, and `register_gtf()` — the same trio available for every other format in polars-bio. GTF support includes predicate pushdown, projection pushdown, attribute flattening, coordinate system handling, compressed files, and object storage (S3, GCS, Azure).
+
+### Basic read
+
+```python
+import polars_bio as pb
+
+df = pb.read_gtf("annotations.gtf")
+df.head()
+```
+
+### Attribute flattening
+
+GTF files store metadata as key-value pairs in the attributes column. Use `attr_fields` to extract specific attributes into their own columns:
+
+```python
+df = pb.read_gtf("annotations.gtf", attr_fields=["gene_id", "gene_name"])
+df.select(["chrom", "start", "end", "type", "gene_id", "gene_name"]).head()
+```
+
+### Lazy scan with filtering
+
+```python
+import polars as pl
+
+exons = (
+    pb.scan_gtf("annotations.gtf")
+    .filter(pl.col("type") == "exon")
+    .collect()
+)
+```
+
+### SQL queries
+
+```python
+pb.register_gtf("annotations.gtf", "genes")
+result = pb.sql("SELECT chrom, start, end, gene_id FROM genes WHERE type = 'exon'")
+```
+
+## Custom SAM Tag Type Inference
+
+Previously, custom/unknown SAM tags (those not in the ~40 well-known tags) defaulted to `Utf8` (string), which meant nanopore-specific integer and float tags like `pt`, `de`, and `ch` would come back as strings. polars-bio 0.26.0 now **samples the file** to infer the correct Arrow type automatically.
+
+### Auto-inference (default)
+
+```python
+# Tags are automatically inferred as Int32, Float32, etc.
+df = pb.read_bam("nanopore.bam", tag_fields=["pt", "de", "ch"])
+print(df.dtypes)  # pt: Int32, de: Float32, ch: Int32
+```
+
+### Explicit type hints
+
+Override or supplement inference with `tag_type_hints`:
+
+```python
+df = pb.read_bam(
+    "nanopore.bam",
+    tag_fields=["pt"],
+    tag_type_hints=["pt:i"],  # force Int32
+)
+```
+
+### Disable inference + use hints only
+
+```python
+df = pb.read_bam(
+    "nanopore.bam",
+    tag_fields=["de"],
+    infer_tag_types=False,
+    tag_type_hints=["de:f"],  # Float32
+)
+```
+
+The `infer_tag_types`, `infer_tag_sample_size`, and `tag_type_hints` parameters are available on `read_bam()`, `scan_bam()`, `read_sam()`, `scan_sam()`, `read_cram()`, `scan_cram()`, `describe_bam()`, `describe_sam()`, `describe_cram()`, and `depth()`.
+
+## Critical Bug Fixes
+
+### Multi-partition write data loss (#338)
+
+When DataFusion's `target_partitions` was greater than 1 (the default on multi-core machines), single-file writes (`write_vcf`, `write_bam`, `write_cram`, `write_fastq`) would silently drop data from all partitions except the first. This release adds a coalesce step before writing, ensuring all data is written correctly.
+
+### VCF contig metadata preservation (#340)
+
+`##contig` header lines were previously lost during VCF write/sink operations. They are now correctly preserved in the output.
+
+## Install
+
+```bash
+pip install polars-bio==0.26.0
+```
+
+- [Documentation](https://biodatageeks.org/polars-bio/)
+- [GitHub](https://github.com/biodatageeks/polars-bio)
+- [PyPI](https://pypi.org/project/polars-bio/)
+- [Changelog](https://github.com/biodatageeks/polars-bio/releases/tag/v0.26.0)

--- a/docs/features.md
+++ b/docs/features.md
@@ -592,6 +592,7 @@ For bioinformatic format there are always three methods available: `read_*` (eag
 | [FASTQ](api.md#polars_bio.data_input.read_fastq) | :white_check_mark: | :white_check_mark: (GZI) | :white_check_mark: |  ❌  |  ❌   |
 | [FASTA](api.md#polars_bio.data_input.read_fasta) | :white_check_mark: |  ❌  | :white_check_mark: |  ❌  |  ❌   |
 | [GFF3](api.md#polars_bio.data_input.read_gff)    | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
+| [GTF](api.md#polars_bio.data_input.read_gtf)     | :white_check_mark: | ❌                  | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [Pairs](api.md#polars_bio.data_input.read_pairs) | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 
 

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -110,7 +110,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.25.0"
+version = "0.26.0"
 description = "Blazing fast genomic operations on large Python dataframes"
 authors = []
 requires-python = ">=3.10"
@@ -37,7 +37,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "polars-bio"
-version = "0.1.0"
+version = "0.26.0"
 description = ""
 authors = ["Marek Wiewiórka <marek.wiewiorka@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version to 0.26.0 across `pyproject.toml`, `Cargo.toml`, `polars_bio/__init__.py`
- Add `[0.26.0]` changelog entry covering all 9 commits since 0.25.0: GTF support (#336), custom SAM tag type inference (#335), multi-partition write fix (#338), VCF contig metadata (#340), security patch (#341), and more
- Add GTF row to the I/O format support table in `docs/features.md`
- Create release blog post (`docs/blog/posts/release-0.26.0.md`) highlighting GTF support, tag inference, and critical bug fixes

## Test plan
- [ ] `grep -r "0\.25\.0" pyproject.toml Cargo.toml polars_bio/__init__.py` returns nothing
- [ ] `grep -r "0\.26\.0" pyproject.toml Cargo.toml polars_bio/__init__.py` matches 3 files
- [ ] CHANGELOG.md renders correctly
- [ ] Docs build: `MKDOCS_EXPORTER_PDF=false ENABLE_MD_EXEC=false ENABLE_MKDOCSTRINGS=false ENABLE_JUPYTER=false JUPYTER_PLATFORM_DIRS=1 mkdocs serve`
- [ ] `python -m pytest tests/test_io_gtf.py tests/test_custom_tag_inference.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)