### PR TITLE
docs: Fix VCF genotypes schema and version references

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -296,12 +296,12 @@ result = pb.overlap(df1, df2, ...)  # Reads from metadata
 
 polars-bio automatically attaches comprehensive metadata to DataFrames when reading genomic files. This metadata includes format information, coordinate systems, and format-specific details like VCF header fields.
 
-### VCF changes since 0.25.0
+### VCF changes since 0.26.0
 
-Compared to `v0.24.0`, VCF handling has the following behavior changes:
+Compared to `v0.25.0`, VCF handling has the following behavior changes:
 
 1. **Multisample FORMAT schema changed (breaking)**
-   Multisample VCF FORMAT data is now exposed as a nested `genotypes` column (`list<struct<sample_id, values>>`) instead of flattened columns like `NA12878_GT`.
+   Multisample VCF FORMAT data is now exposed as a nested `genotypes` column (`struct<GT: list, DP: list, ...>`) instead of flattened columns like `NA12878_GT`. Sample names are available via `meta["header"]["sample_names"]`; each FORMAT field contains a list of values ordered by sample.
 
 2. **Single-sample FORMAT schema unchanged**
    Single-sample VCFs still expose FORMAT fields as top-level columns (`GT`, `DP`, `GQ`, ...).

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -293,7 +293,7 @@ class IOOperations:
         Parameters:
             path: The path to the VCF file.
             info_fields: List of INFO field names to include. If *None*, all INFO fields from the VCF header are included by default. Use this to limit fields for better performance.
-            format_fields: List of FORMAT field names to include (per-sample genotype data). If *None*, all FORMAT fields are included by default. For **single-sample** VCFs, FORMAT fields are top-level columns (e.g., `GT`, `DP`). For **multi-sample** VCFs, FORMAT data is exposed as a nested `genotypes` column (`list<struct<sample_id, values>>`).
+            format_fields: List of FORMAT field names to include (per-sample genotype data). If *None*, all FORMAT fields are included by default. For **single-sample** VCFs, FORMAT fields are top-level columns (e.g., `GT`, `DP`). For **multi-sample** VCFs, FORMAT data is exposed as a nested `genotypes` column (`struct<GT: list, DP: list, ...>`) with sample names in `meta["header"]["sample_names"]`.
             samples: Optional list of sample names to include from the VCF header. Matching is exact and case-sensitive. Missing sample names are skipped with a warning. The output follows the requested sample order.
             chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
             concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
@@ -390,7 +390,7 @@ class IOOperations:
         Parameters:
             path: The path to the VCF file.
             info_fields: List of INFO field names to include. If *None*, all INFO fields from the VCF header are included by default. Use this to limit fields for better performance.
-            format_fields: List of FORMAT field names to include (per-sample genotype data). If *None*, all FORMAT fields are included by default. For **single-sample** VCFs, FORMAT fields are top-level columns (e.g., `GT`, `DP`). For **multi-sample** VCFs, FORMAT data is exposed as a nested `genotypes` column (`list<struct<sample_id, values>>`).
+            format_fields: List of FORMAT field names to include (per-sample genotype data). If *None*, all FORMAT fields are included by default. For **single-sample** VCFs, FORMAT fields are top-level columns (e.g., `GT`, `DP`). For **multi-sample** VCFs, FORMAT data is exposed as a nested `genotypes` column (`struct<GT: list, DP: list, ...>`) with sample names in `meta["header"]["sample_names"]`.
             samples: Optional list of sample names to include from the VCF header. Matching is exact and case-sensitive. Missing sample names are skipped with a warning. The output follows the requested sample order.
             chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
             concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.


### PR DESCRIPTION
- Update version refs from 0.25.0/0.24.0 to 0.26.0/0.25.0
- Fix genotypes schema from legacy `list<struct<sample_id, values>>` to current `struct<GT: list, DP: list, ...>` with sample names in metadata