### PR TITLE
chore: Bump Rust toolchain from 1.88.0 to 1.91.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.91.0"
 components = ["rustfmt"]


### PR DESCRIPTION
## Summary
- Bumps Rust toolchain from 1.88.0 to 1.91.0 in `rust-toolchain.toml`
- Verified project compiles cleanly with `cargo check`

## Test plan
- [ ] CI passes with the new toolchain version

🤖 Generated with [Claude Code](https://claude.com/claude-code)