### PR TITLE
feat: Add register_extension() for external session plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "333638a" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "333638a" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "d71e978c3b35fd21830e6a125693856f9083aaa1" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "d71e978c3b35fd21830e6a125693856f9083aaa1", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -778,6 +778,91 @@ print(df.execution_plan())
     `COUNT(*)` queries also benefit — when no columns are needed, the empty projection path avoids parsing any fields while still counting records correctly.
 
 
+## External Extension Registration
+
+polars-bio exposes a `register_extension()` method on `BioSessionContext` that allows external PyO3 crates to register UDFs, UDTFs, and table providers into the shared DataFusion session — without modifying polars-bio itself.
+
+### Mechanism
+
+The method passes a raw pointer to the inner `SessionContext` plus the `DATAFUSION_VERSION` string to a Python callback. The external crate's callback casts the pointer back, verifies ABI compatibility, and registers its functions:
+
+```mermaid
+sequenceDiagram
+    participant Python
+    participant polars_bio as polars-bio (Rust)
+    participant vepyr as Extension (Rust)
+
+    Python->>polars_bio: ctx.register_extension(callback)
+    polars_bio->>polars_bio: ptr = &mut self.ctx as *mut SessionContext
+    polars_bio->>Python: callback(ptr, DATAFUSION_VERSION)
+    Python->>vepyr: _register_vep(ptr, version)
+    vepyr->>vepyr: verify DATAFUSION_VERSION matches
+    vepyr->>vepyr: ctx = unsafe { &*(ptr as *const SessionContext) }
+    vepyr->>vepyr: register_vep_functions(ctx)
+```
+
+### Safety contract
+
+The extension crate **must** be compiled with the exact same `datafusion` crate version, feature flags, and Rust toolchain as polars-bio. Casting the pointer from a mismatched build is undefined behavior, even if `DATAFUSION_VERSION` strings match.
+
+The pointer is valid only for the duration of the callback. The callback must not store or use it after returning.
+
+### Example: vepyr integration
+
+[vepyr](https://github.com/biodatageeks/vepyr) uses this mechanism to register VEP annotation functions (`annotate_vep()`, `lookup_variants()`, and scalar UDFs) into the polars-bio session:
+
+```python
+import polars_bio as pb
+import vepyr
+
+# VEP functions auto-register on first use of vepyr.annotate()
+# Or register explicitly:
+pb.ctx.register_extension(vepyr._core._register_vep)
+
+# Now annotate_vep() is available as a SQL table function
+pb.register_vcf("input.vcf", "vcf")
+result = pb.sql(
+    "SELECT * FROM annotate_vep('vcf', '/data/cache/variation', 'parquet', '{}')"
+).collect()
+```
+
+### Writing an extension
+
+To create your own extension that registers functions into polars-bio's session:
+
+**Rust side** — implement a `#[pyfunction]` that takes the pointer and version:
+
+```rust
+use datafusion::prelude::SessionContext;
+
+#[pyfunction]
+fn _register_my_functions(ctx_ptr: usize, datafusion_version: &str) -> PyResult<()> {
+    // 1. Verify ABI compatibility
+    if datafusion_version != datafusion::DATAFUSION_VERSION {
+        return Err(PyRuntimeError::new_err("DataFusion version mismatch"));
+    }
+    // 2. Cast pointer back to SessionContext
+    let ctx = unsafe { &*(ctx_ptr as *const SessionContext) };
+    // 3. Register your functions
+    ctx.register_udf(my_udf());
+    ctx.register_udtf("my_table_func", Arc::new(MyTableFunction::new()));
+    Ok(())
+}
+```
+
+**Python side** — call `register_extension`:
+
+```python
+import polars_bio as pb
+from my_extension._core import _register_my_functions
+
+pb.ctx.register_extension(_register_my_functions)
+```
+
+!!! warning
+    This is an **unsafe** escape hatch. If the extension is compiled against a different `datafusion` version or with different compiler flags, the pointer cast will produce undefined behavior. Always build polars-bio and extensions from the same CI pipeline or workspace.
+
+
 ## Building & Development
 
 ### Building from source

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,18 +67,18 @@ impl PyBioSessionContext {
 
     /// Register an external extension into this session.
     ///
-    /// The callback receives a raw pointer (as `usize`) to the inner
-    /// `datafusion::prelude::SessionContext`. The extension can cast it
-    /// back and register UDFs, UDTFs, or table providers.
+    /// The callback receives:
+    ///   - `ctx_ptr`: raw pointer (as `usize`) to the inner `SessionContext`
+    ///   - `datafusion_version`: version string for ABI compatibility check
     ///
-    /// # Safety
-    ///
-    /// The pointer is valid only for the duration of the callback.
-    /// The callback must not store or use it after returning.
+    /// The extension must verify the datafusion version matches before
+    /// casting the pointer. The pointer is valid only for the duration
+    /// of the callback.
     #[pyo3(signature = (callback))]
     pub fn register_extension(&mut self, py: Python<'_>, callback: PyObject) -> PyResult<()> {
         let ptr = &self.ctx as *const SessionContext as usize;
-        callback.call1(py, (ptr,))?;
+        let df_version = datafusion::DATAFUSION_VERSION;
+        callback.call1(py, (ptr, df_version))?;
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -68,15 +68,18 @@ impl PyBioSessionContext {
     /// Register an external extension into this session.
     ///
     /// The callback receives:
-    ///   - `ctx_ptr`: raw pointer (as `usize`) to the inner `SessionContext`
+    ///   - `ctx_ptr`: mutable raw pointer (as `usize`) to the inner `SessionContext`
     ///   - `datafusion_version`: version string for ABI compatibility check
     ///
-    /// The extension must verify the datafusion version matches before
-    /// casting the pointer. The pointer is valid only for the duration
-    /// of the callback.
-    #[pyo3(signature = (callback))]
+    /// **Safety contract**: The extension crate MUST be compiled with the exact
+    /// same `datafusion` crate version, feature flags, and Rust toolchain as
+    /// this library. Casting the pointer from a mismatched build is undefined
+    /// behavior, even if `DATAFUSION_VERSION` strings match.
+    ///
+    /// The pointer is valid only for the duration of the callback.
+    /// The callback must not store or use it after returning.
     pub fn register_extension(&mut self, py: Python<'_>, callback: PyObject) -> PyResult<()> {
-        let ptr = &self.ctx as *const SessionContext as usize;
+        let ptr = &mut self.ctx as *mut SessionContext as usize;
         let df_version = datafusion::DATAFUSION_VERSION;
         callback.call1(py, (ptr, df_version))?;
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_bio_function_ranges::{register_ranges_functions, BioConfig, BioSessionExt};
 use datafusion_python::dataframe::PyDataFrame;
 use log::debug;
-use pyo3::{pyclass, pymethods, PyResult, Python};
+use pyo3::{pyclass, pymethods, PyObject, PyResult, Python};
 use tokio::runtime::Runtime;
 
 #[pyclass(name = "BioSessionContext")]
@@ -62,6 +62,23 @@ impl PyBioSessionContext {
                 name, e
             ))
         })?;
+        Ok(())
+    }
+
+    /// Register an external extension into this session.
+    ///
+    /// The callback receives a raw pointer (as `usize`) to the inner
+    /// `datafusion::prelude::SessionContext`. The extension can cast it
+    /// back and register UDFs, UDTFs, or table providers.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is valid only for the duration of the callback.
+    /// The callback must not store or use it after returning.
+    #[pyo3(signature = (callback))]
+    pub fn register_extension(&mut self, py: Python<'_>, callback: PyObject) -> PyResult<()> {
+        let ptr = &self.ctx as *const SessionContext as usize;
+        callback.call1(py, (ptr,))?;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,19 +272,9 @@ fn py_read_sql(
     #[allow(clippy::useless_conversion)]
     py.allow_threads(|| {
         let rt = Runtime::new()?;
-        // Clone the SessionContext (cheap, Arc-based) so we can move it into
-        // a spawned task. Running SQL on a worker thread is required for table
-        // functions that use block_in_place() internally.
-        let ctx = py_ctx.ctx.clone();
+        let ctx = &py_ctx.ctx;
         let df = rt
-            .block_on(async move {
-                let task = tokio::task::spawn(async move {
-                    ctx.sql(&sql_text).await
-                });
-                task.await.map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!("{e}"))
-                })?
-            })
+            .block_on(ctx.sql(&sql_text))
             .map_err(|e| PyValueError::new_err(format!("SQL query failed: {}", e)))?;
         Ok(PyDataFrame::new(df))
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,24 +272,20 @@ fn py_read_sql(
     #[allow(clippy::useless_conversion)]
     py.allow_threads(|| {
         let rt = Runtime::new()?;
+        // Clone the SessionContext (cheap, Arc-based) so we can move it into
+        // a spawned task. Running SQL on a worker thread is required for table
+        // functions that use block_in_place() internally.
         let ctx = py_ctx.ctx.clone();
-        eprintln!("[py_read_sql] entering block_on with spawn");
         let df = rt
             .block_on(async move {
-                eprintln!("[py_read_sql] inside block_on, spawning task");
                 let task = tokio::task::spawn(async move {
-                    eprintln!("[py_read_sql] inside spawn, calling ctx.sql()");
-                    let result = ctx.sql(&sql_text).await;
-                    eprintln!("[py_read_sql] ctx.sql() returned: {:?}", result.is_ok());
-                    result
+                    ctx.sql(&sql_text).await
                 });
-                eprintln!("[py_read_sql] awaiting task");
                 task.await.map_err(|e| {
                     datafusion::error::DataFusionError::Execution(format!("{e}"))
                 })?
             })
             .map_err(|e| PyValueError::new_err(format!("SQL query failed: {}", e)))?;
-        eprintln!("[py_read_sql] done");
         Ok(PyDataFrame::new(df))
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,9 +272,20 @@ fn py_read_sql(
     #[allow(clippy::useless_conversion)]
     py.allow_threads(|| {
         let rt = Runtime::new()?;
-        let ctx = &py_ctx.ctx;
+        // Clone the SessionContext (cheap — it's Arc-based internally) so we
+        // can move it into a spawned task on a worker thread. This is required
+        // because table functions like annotate_vep() call block_in_place()
+        // internally, which deadlocks on the block_on driver thread.
+        let ctx = py_ctx.ctx.clone();
         let df = rt
-            .block_on(ctx.sql(&sql_text))
+            .block_on(async move {
+                let task = tokio::task::spawn(async move {
+                    ctx.sql(&sql_text).await
+                });
+                task.await.map_err(|e| {
+                    datafusion::error::DataFusionError::Execution(format!("{e}"))
+                })?
+            })
             .map_err(|e| PyValueError::new_err(format!("SQL query failed: {}", e)))?;
         Ok(PyDataFrame::new(df))
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,21 +272,24 @@ fn py_read_sql(
     #[allow(clippy::useless_conversion)]
     py.allow_threads(|| {
         let rt = Runtime::new()?;
-        // Clone the SessionContext (cheap — it's Arc-based internally) so we
-        // can move it into a spawned task on a worker thread. This is required
-        // because table functions like annotate_vep() call block_in_place()
-        // internally, which deadlocks on the block_on driver thread.
         let ctx = py_ctx.ctx.clone();
+        eprintln!("[py_read_sql] entering block_on with spawn");
         let df = rt
             .block_on(async move {
+                eprintln!("[py_read_sql] inside block_on, spawning task");
                 let task = tokio::task::spawn(async move {
-                    ctx.sql(&sql_text).await
+                    eprintln!("[py_read_sql] inside spawn, calling ctx.sql()");
+                    let result = ctx.sql(&sql_text).await;
+                    eprintln!("[py_read_sql] ctx.sql() returned: {:?}", result.is_ok());
+                    result
                 });
+                eprintln!("[py_read_sql] awaiting task");
                 task.await.map_err(|e| {
                     datafusion::error::DataFusionError::Execution(format!("{e}"))
                 })?
             })
             .map_err(|e| PyValueError::new_err(format!("SQL query failed: {}", e)))?;
+        eprintln!("[py_read_sql] done");
         Ok(PyDataFrame::new(df))
     })
 }


### PR DESCRIPTION
## Summary

- Adds `register_extension(callback)` method to `BioSessionContext`
- The callback receives a raw pointer (`usize`) to the inner `SessionContext`
- External PyO3 crates can cast it back and register UDFs/UDTFs/table providers

## Use case

Enables [vepyr](https://github.com/biodatageeks/vepyr) to register VEP annotation functions (`annotate_vep()`, `lookup_variants()`, etc.) into polars-bio's session without modifying polars-bio itself:

```python
import polars_bio as pb
import vepyr

# Register VEP functions into polars-bio's session
pb.ctx.register_extension(vepyr._core._register_vep)

# Now annotate_vep() is available in SQL
lf = pb.scan_vcf("input.vcf")
result = pb.sql("SELECT * FROM annotate_vep('vcf', '/cache/parquet', 'parquet')")
```

## Safety

The pointer is valid only for the duration of the callback. The callback must not store or use it after returning.

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)