### PR TITLE
fix: GTF attr_fields returns all values for duplicate keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1224,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1345,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.1.1#207222185cbe7fb507f06b157c7431f769cc909d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.1.1" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }

--- a/tests/test_io_gtf.py
+++ b/tests/test_io_gtf.py
@@ -199,6 +199,26 @@ class TestIOGTF:
         assert result_on["type"].to_list() == result_off["type"].to_list()
         assert result_on["chrom"].to_list() == result_off["chrom"].to_list()
 
+    def test_attr_fields_duplicate_keys_concatenated(self):
+        """attr_fields with duplicate keys (tag) returns comma-separated values (issue #358)."""
+        df = pb.read_gtf(GTF_PATH, attr_fields=["tag", "gene_id"])
+        assert "tag" in df.columns
+        assert "gene_id" in df.columns
+        # All 23 rows have: tag "basic"; tag "TAGENE"; tag "appris_principal_3"; tag "CCDS"
+        for i in range(len(df)):
+            tag_val = df["tag"][i]
+            assert (
+                tag_val == "basic,TAGENE,appris_principal_3,CCDS"
+            ), f"Row {i}: expected comma-separated tags, got {tag_val!r}"
+        # gene_id (single-occurrence key) should still work normally
+        assert df["gene_id"][0] == "ENSG00000111640.16"
+
+    def test_scan_attr_fields_duplicate_keys(self):
+        """scan_gtf + attr_fields with duplicate keys works via lazy path."""
+        df = pb.scan_gtf(GTF_PATH).select(["tag", "gene_name"]).collect()
+        assert df["tag"][0] == "basic,TAGENE,appris_principal_3,CCDS"
+        assert df["gene_name"][0] == "GAPDH"
+
     def test_compression_type_override(self, tmp_path):
         """Explicit compression_type overrides auto-detection."""
         # Create a gzip file with .gtf.gz extension but read with explicit compression_type


### PR DESCRIPTION
## Summary

Closes #358

- Bump `datafusion-bio-formats` to `33b2a93e` (merged fix from biodatageeks/datafusion-bio-formats#165) which concatenates duplicate GTF attribute keys with commas, consistent with GFF3 multi-value handling
- Add two tests: `test_attr_fields_duplicate_keys_concatenated` (read_gtf path) and `test_scan_attr_fields_duplicate_keys` (scan_gtf lazy path)

## Test plan

- [x] All 25 GTF tests pass (`pytest tests/test_io_gtf.py -v`)
- [x] `read_gtf(..., attr_fields=["tag"])` returns `"basic,TAGENE,appris_principal_3,CCDS"` for all rows
- [x] `scan_gtf` lazy path also returns concatenated duplicate tags
- [x] Single-occurrence keys (gene_id, gene_name) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)