### PR TITLE
feat: Add typed BAM/SAM tag roundtrip support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,8 +1197,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1223,8 +1223,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1247,8 +1247,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1258,6 +1258,7 @@ dependencies = [
  "log",
  "noodles 0.93.0",
  "noodles-bgzf 0.36.0",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
  "noodles-sam 0.78.0",
  "opendal",
  "serde",
@@ -1269,8 +1270,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1295,8 +1296,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1319,8 +1320,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1344,8 +1345,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1373,8 +1374,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1398,8 +1399,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1426,8 +1427,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
+version = "1.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=487f62d64a075bb33705ac6c560538d4ba66173b#487f62d64a075bb33705ac6c560538d4ba66173b"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,8 +1197,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1223,8 +1223,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1247,8 +1247,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,8 +1269,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1295,8 +1295,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1319,8 +1319,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1344,8 +1344,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1373,8 +1373,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1398,8 +1398,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1426,8 +1426,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.1.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=33b2a93e5b1842a308da00360e646bd73dde5f09#33b2a93e5b1842a308da00360e646bd73dde5f09"
+version = "1.2.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=95787c8be9cbb8137a72b094161978f3213ac0e4#95787c8be9cbb8137a72b094161978f3213ac0e4"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -4238,7 +4238,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polars_bio"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "487f62d64a075bb33705ac6c560538d4ba66173b" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "33b2a93e5b1842a308da00360e646bd73dde5f09" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "95787c8be9cbb8137a72b094161978f3213ac0e4" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9ef64a1f16bedf4096ae37a0b332ce15f3a18255", default-features = false }

--- a/docs/features.md
+++ b/docs/features.md
@@ -914,7 +914,17 @@ df = df.with_columns(
 )
 
 pb.write_bam(df, "with_tags.bam")
+
+# BAM optional tags are only parsed when requested on read.
+roundtrip = pb.read_bam(
+    "with_tags.bam",
+    tag_fields=["XI", "XF", "XZ", "ML", "FZ"],
+)
 ```
+
+If you call `read_bam("with_tags.bam")` or `scan_bam("with_tags.bam")` without
+`tag_fields`, you will only see the 12 core BAM columns. The tags are still present in
+the file; they are simply not parsed by default.
 
 For ambiguous string tags such as `A` (single ASCII character) and `H` (hex), pass
 `tag_type_overrides` explicitly:

--- a/docs/features.md
+++ b/docs/features.md
@@ -894,6 +894,68 @@ filtered = df.filter(pl.col("mapping_quality") > 20)
 pb.write_bam(filtered, "filtered.bam")
 ```
 
+### Adding BAM/SAM Tags on Write
+
+You can create new BAM/SAM tag columns with standard Polars expressions and write them back out.
+For most numeric, string, and array tags, the SAM type is inferred from the column dtype:
+
+```python
+import polars as pl
+import polars_bio as pb
+
+df = pb.read_bam("input.bam").head(2)
+
+df = df.with_columns(
+    pl.Series("XI", [7, 8], dtype=pl.Int32),             # integer tag
+    pl.Series("XF", [0.25, 0.50], dtype=pl.Float32),     # float tag
+    pl.Series("XZ", ["alpha", "beta"], dtype=pl.Utf8),   # string tag (Z)
+    pl.Series("ML", [[1, 2, 3], [2, 3, 4]], dtype=pl.List(pl.UInt8)),   # B:C
+    pl.Series("FZ", [[1000, 2000], [1001, 2001]], dtype=pl.List(pl.UInt16)),  # B:S
+)
+
+pb.write_bam(df, "with_tags.bam")
+```
+
+For ambiguous string tags such as `A` (single ASCII character) and `H` (hex), pass
+`tag_type_overrides` explicitly:
+
+```python
+import polars as pl
+import polars_bio as pb
+
+df = pb.read_bam("input.bam").head(2).with_columns(
+    pl.Series("XA", ["A", "B"], dtype=pl.Utf8),          # should be SAM type A
+    pl.Series("XH", ["0A0B", "C0FFEE"], dtype=pl.Utf8),  # should be SAM type H
+)
+
+pb.write_bam(
+    df,
+    "with_ambiguous_tags.bam",
+    tag_type_overrides={"XA": "A", "XH": "H"},
+)
+```
+
+The same parameter is available on `write_sam()`, `sink_bam()`, `sink_sam()`, and the
+Polars namespace methods (`df.pb.write_bam(...)`, `lf.pb.sink_sam(...)`).
+
+If a tag already existed in the source BAM/SAM and was read with its exact type, that type
+is preserved automatically through ordinary Polars transforms:
+
+```python
+import polars as pl
+import polars_bio as pb
+
+df = pb.read_bam("input.bam", tag_fields=["tp", "ML"])
+
+edited = df.with_columns(
+    pl.col("tp"),
+    pl.col("ML"),
+)
+
+# Existing exact tag types are preserved; no override needed here.
+pb.write_bam(edited, "roundtrip.bam")
+```
+
 ### Polars Extension Methods
 
 Write functions are also available as Polars namespace extensions:
@@ -991,9 +1053,8 @@ schema = pb.describe_cram("file.cram")
 
 ### BAM Optional Tags
 
-polars-bio supports reading BAM optional alignment tags as individual columns. Tags are only parsed when explicitly requested, ensuring zero overhead for standard reads.
-
-> **Note**: CRAM tag support is planned for a future release. The `tag_fields` parameter is accepted for CRAM functions but currently ignored with a warning.
+polars-bio supports reading BAM, SAM, and CRAM optional alignment tags as individual columns.
+Tags are only parsed when explicitly requested, ensuring zero overhead for standard reads.
 
 #### Usage
 
@@ -1016,7 +1077,18 @@ high_quality = lf.filter((pl.col("NM") <= 2) & (pl.col("AS") >= 100)).collect()
 # SQL queries (tags must be quoted)
 pb.register_bam("alignments.bam", "reads", tag_fields=["NM", "RG"])
 result = pb.sql('SELECT name, "NM" FROM reads WHERE "NM" <= 2').collect()
+
+# Exact type hints for custom or array tags
+typed = pb.read_bam(
+    "alignments.bam",
+    tag_fields=["tp", "ML", "FZ"],
+    infer_tag_types=False,
+    tag_type_hints=["tp:A", "ML:B:C", "FZ:B:S"],
+)
 ```
+
+`tag_type_hints` accepts scalar forms such as `NM:i`, `de:f`, `tp:A`, `XH:H`,
+plus array forms `TAG:B` and `TAG:B:SUBTYPE` such as `ML:B:C` or `FZ:B:S`.
 
 #### Common Tags
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1099,6 +1099,8 @@ typed = pb.read_bam(
 
 `tag_type_hints` accepts scalar forms such as `NM:i`, `de:f`, `tp:A`, `XH:H`,
 plus array forms `TAG:B` and `TAG:B:SUBTYPE` such as `ML:B:C` or `FZ:B:S`.
+Bare `TAG:B` is treated as the default integer-array hint and normalized to
+`TAG:B:i` internally, so it reads back as `list[i32]`.
 
 #### Common Tags
 

--- a/openspec/changes/add-bam-sam-typed-tag-roundtrip/design.md
+++ b/openspec/changes/add-bam-sam-typed-tag-roundtrip/design.md
@@ -1,0 +1,175 @@
+## Context
+
+The current BAM/SAM tag path in `polars-bio` is split across three layers:
+
+1. Python read APIs validate user hints in `polars_bio/io.py` and `polars_bio/sql.py`.
+2. Rust scan registration in `src/scan.rs` forwards those options to `BamTableProvider::new`.
+3. Rust write logic in `src/write.rs` reconstructs BAM tag metadata before serialization.
+
+The scan path is already wired for typed tag support, but two concrete limitations remain in `polars-bio` itself:
+
+- `_validate_tag_type_hints()` only accepts scalar type codes `{i, f, Z, A, H}`.
+- `add_bam_tag_metadata()` preserves existing `BAM_TAG_TYPE_KEY` when it survives, otherwise it falls back to broad Arrow inference (`Utf8 -> Z`, any list -> `B`).
+
+As of April 9, 2026, upstream `datafusion-bio-formats#170` contains the backend work needed for full typed BAM/SAM roundtrips, but that PR is still open. Its head SHA is `95787c8be9cbb8137a72b094161978f3213ac0e4`, and the current `polars-bio` pin still points at `33b2a93e5b1842a308da00360e646bd73dde5f09`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Accept explicit `B`-type read hints including exact array subtypes.
+- Preserve exact SAM tag typing across ordinary Polars transforms.
+- Allow callers to declare exact types for newly created ambiguous write-time tags.
+- Keep typed scalar and array tags stable across eager and lazy BAM/SAM roundtrips.
+- Add focused regression coverage for the workflows described in issues `#362` to `#365`.
+
+### Non-Goals
+
+- Re-implement BAM/SAM optional-field parsing or serialization logic that already exists upstream.
+- Change the semantics of non-tag BAM/SAM columns.
+- Add CRAM-specific behavior beyond what falls out naturally from the updated backend dependency.
+
+## Decisions
+
+### Decision 1: Align to the backend revision that contains `datafusion-bio-formats#170`
+
+`polars-bio` should not add local decoding shims for features that upstream now supports. The change should pin all `datafusion-bio-format-*` crates to a revision that includes the full typed optional-field roundtrip work from PR `#170`.
+
+Implementation guidance:
+
+- Preferred target: the merged commit on `master` once upstream PR `#170` lands.
+- Temporary fallback if implementation starts before merge: pin to head SHA `95787c8be9cbb8137a72b094161978f3213ac0e4` and replace it with the merged revision before release.
+
+Reasoning:
+
+- PR `#170` explicitly closes the upstream gaps referenced by issues `#362` and `#363`.
+- It also adds exact `B` subtype handling, wide numeric coercions, and hex handling that `polars-bio` should consume rather than duplicate.
+
+### Decision 2: Expand read-side hint grammar instead of inventing a new syntax
+
+Read APIs should continue using SAM-style hint strings, but the validator must accept the full grammar:
+
+- Scalar: `TAG:i`, `TAG:f`, `TAG:Z`, `TAG:A`, `TAG:H`
+- Array, default subtype: `TAG:B`
+- Array, explicit subtype: `TAG:B:c`, `TAG:B:C`, `TAG:B:s`, `TAG:B:S`, `TAG:B:i`, `TAG:B:I`, `TAG:B:f`
+
+Validation rules:
+
+- `TAG` remains exactly two characters.
+- `B` hints may have either two segments (`TAG:B`) or three segments (`TAG:B:SUBTYPE`).
+- Only the SAM array subtype codes above are accepted in the third segment.
+
+This keeps read-side user input aligned with upstream parsing and with the examples already referenced in issue `#365`.
+
+### Decision 3: Preserve tag typing in `source_header` metadata
+
+Arrow field metadata is not reliable after `with_columns`, `filter`, `select`, and similar Polars operations, but the existing `config_meta` / `source_header` channel does survive those transforms.
+
+The change should extend BAM/SAM metadata extraction to populate a header-level map such as:
+
+```json
+{
+  "tag_types": {
+    "tp": "A",
+    "XH": "H",
+    "ML": "B:C",
+    "FZ": "B:S"
+  }
+}
+```
+
+Data flow:
+
+1. On read, inspect field-level `BAM_TAG_TYPE_KEY` metadata and copy exact tag type strings into BAM/SAM `source_header`.
+2. Preserve that header metadata through Polars transformations using the existing `set_source_metadata()` / `get_metadata()` path.
+3. On write, consult preserved tag type metadata before falling back to Arrow dtype inference.
+
+This solves the transformed-existing-tag case from issue `#364` without depending on Arrow field metadata surviving a DataFrame rewrite.
+
+### Decision 4: Add explicit write-time overrides for ambiguous new tags
+
+Metadata preservation solves roundtrips for existing tags, but it does not help when a caller creates a new `Utf8` tag column from scratch. For those cases the write API needs an explicit override surface.
+
+Add optional `tag_type_overrides: dict[str, str] | None` to:
+
+- `write_bam`
+- `sink_bam`
+- `write_sam`
+- `sink_sam`
+
+Accepted values use the same exact type strings as preserved metadata:
+
+- `A`, `H`, `Z`, `i`, `f`
+- `B`
+- `B:c`, `B:C`, `B:s`, `B:S`, `B:i`, `B:I`, `B:f`
+
+Resolution order in the write path:
+
+1. `tag_type_overrides`
+2. Preserved `source_header["tag_types"]`
+3. Existing Arrow field metadata (`BAM_TAG_TYPE_KEY`)
+4. Arrow dtype inference
+
+Consequences:
+
+- Existing transformed `A` / `H` tags retain fidelity automatically.
+- Newly added ambiguous string tags can be written correctly without requiring users to manage internal metadata helpers.
+- Exact list subtypes can still be forced when needed, even though most array cases can be inferred from the list element dtype.
+
+### Decision 5: Keep the Rust writer responsible for the final schema metadata
+
+The Python layer should collect and pass override / preserved type information, but `src/write.rs` should remain the single place that materializes BAM tag metadata on the outgoing Arrow schema.
+
+Required changes:
+
+- Extend `BamWriteOptions` and the shared write plumbing so Python can pass serialized `tag_type_overrides`.
+- Teach `add_bam_tag_metadata()` to work with exact type strings instead of single-character fallbacks.
+- Infer exact array subtype strings from list element dtypes when no explicit metadata exists.
+
+This keeps the serialization contract close to the code that already knows how to decorate BAM/SAM schemas before upstream serialization.
+
+## Test Strategy
+
+### Unit tests
+
+- `polars_bio/io.py` hint validation:
+  - accepts valid scalar and `B` subtype hints
+  - rejects malformed `TAG:B:X`, missing subtype tokens, and non-2-character tag names
+- metadata plumbing:
+  - BAM/SAM source metadata includes exact `tag_types`
+  - `tag_types` survive representative `DataFrame` and `LazyFrame` transforms
+- write override validation:
+  - accepted override strings mirror read-side grammar
+  - malformed overrides fail before entering Rust
+
+### End-to-end integration tests
+
+- Read-side typed tag coverage using existing nanopore BAM plus temporary SAM conversion:
+  - scalar custom tags: `A`, `i`, `f`, `Z`, `H`
+  - array tags: `B:c`, `B:C`, `B:s`, `B:S`, `B:i`, `B:I`, `B:f`
+  - standard tags: `ML -> list[u8]`, `FZ -> list[u16]`
+- Write-side roundtrips for both eager and lazy APIs:
+  - `read_bam -> with_columns -> write_bam -> read_bam`
+  - `scan_bam -> with_columns -> sink_bam -> read_bam`
+  - matching SAM paths, excluding `CG` as a required assertion
+- Ambiguous tag fidelity:
+  - transformed existing `A` / `H` tags write back with the same exact type
+  - newly created `A` / `H` tags roundtrip correctly when `tag_type_overrides` is supplied
+- Mixed-tag scenarios:
+  - preserve existing tags while adding new scalar and array tags
+  - cover wide numeric inputs (`Int64`, `UInt64`, `Float64`) that the updated backend is expected to narrow safely
+
+### Fixture strategy
+
+- Reuse `tests/data/io/bam/nanopore_custom_tags.bam` and SAM converted from it for most custom tag coverage.
+- Keep `CG` assertions BAM-only.
+- If no existing fixture exposes `ML`, `FZ`, or `H`, generate a minimal temporary BAM fixture with `pysam` inside the tests instead of adding a large binary asset.
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Upstream PR `#170` is still open | Medium | Use the PR head SHA temporarily or wait for merge before implementation starts |
+| Metadata model adds another BAM-specific header key | Low | Store it under existing `source_header` plumbing rather than creating a parallel metadata system |
+| Override API overlaps with preserved metadata | Low | Document and test a strict precedence order |
+| SAM cannot require BAM-only `CG` behavior | Low | Keep `CG` assertions restricted to BAM fixtures and exclude it from required SAM roundtrips |

--- a/openspec/changes/add-bam-sam-typed-tag-roundtrip/proposal.md
+++ b/openspec/changes/add-bam-sam-typed-tag-roundtrip/proposal.md
@@ -1,0 +1,50 @@
+# Change: Add typed BAM/SAM optional tag roundtrip support
+
+GitHub issues:
+- https://github.com/biodatageeks/polars-bio/issues/362
+- https://github.com/biodatageeks/polars-bio/issues/363
+- https://github.com/biodatageeks/polars-bio/issues/364
+- https://github.com/biodatageeks/polars-bio/issues/365
+
+Upstream dependency:
+- https://github.com/biodatageeks/datafusion-bio-formats/pull/170
+
+## Why
+
+`polars-bio` already threads BAM/SAM read options such as `tag_fields`, `infer_tag_types`, `infer_tag_sample_size`, and `tag_type_hints` into `BamTableProvider::new`, but the repo is still pinned to `datafusion-bio-formats` revision `33b2a93e5b1842a308da00360e646bd73dde5f09`, which predates the backend work needed for full typed optional-field support.
+
+That leaves four user-visible gaps:
+
+1. `tag_type_hints` validation rejects `B` array hints and subtype forms such as `ML:B:C` or `pa:B:i`.
+2. Exact SAM tag typing for `A`, `H`, and `B` subtypes is lost after normal Polars transforms because Arrow field metadata does not survive those operations.
+3. Write APIs do not have an explicit escape hatch for ambiguous new tags whose Arrow dtype alone cannot distinguish `A`, `H`, and `Z`.
+4. The test suite does not cover full read -> add tag(s) -> write -> read-back workflows for eager and lazy BAM/SAM APIs.
+
+## What Changes
+
+- Update `datafusion-bio-format-*` dependencies to a revision that includes the backend work from `datafusion-bio-formats#170` that closes the serializer and hint parsing gaps tracked by upstream issues `#168` and `#169`.
+- Extend Python read-side hint validation and docstrings to accept `TAG:B` and `TAG:B:SUBTYPE` grammar in addition to existing scalar forms.
+- Extract exact BAM/SAM tag typing into `source_header` metadata so transformed `DataFrame` and `LazyFrame` objects retain the original SAM type information.
+- Add optional write-time `tag_type_overrides` support for BAM/SAM sinks so callers can explicitly declare ambiguous or newly created tag columns.
+- Update the Rust BAM/SAM write path to resolve exact tag types from overrides, preserved metadata, existing field metadata, and Arrow dtype inference in that order.
+- Add regression coverage for typed scalar tags, typed array tags, transformed existing tags, newly injected tags, eager write paths, and lazy sink paths.
+- Document the read/write semantics for typed custom tags, including standard tags such as `ML` and `FZ`.
+
+## Impact
+
+- Affected specs: `bam-tags` (new capability spec).
+- Affected code:
+  - `Cargo.toml`, `Cargo.lock`
+  - `polars_bio/io.py`
+  - `polars_bio/sql.py`
+  - `polars_bio/_metadata.py`
+  - `polars_bio/metadata_extractors.py`
+  - `src/option.rs`
+  - `src/write.rs`
+  - `tests/test_custom_tag_inference.py`
+  - `tests/test_io_bam.py`
+  - `tests/test_source_metadata.py`
+- User-visible behavior:
+  - `read_bam` / `scan_bam` / `read_sam` / `scan_sam` accept exact `B`-type hints.
+  - `write_bam` / `sink_bam` / `write_sam` / `sink_sam` preserve or explicitly apply exact SAM tag types instead of degrading `A`/`H` to `Z` or collapsing array subtypes to bare `B`.
+

--- a/openspec/changes/add-bam-sam-typed-tag-roundtrip/specs/bam-tags/spec.md
+++ b/openspec/changes/add-bam-sam-typed-tag-roundtrip/specs/bam-tags/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: BAM and SAM read APIs accept exact optional tag type hints
+
+`read_bam`, `scan_bam`, `read_sam`, and `scan_sam` SHALL accept explicit optional tag hints for both scalar SAM tag types and `B` array types.
+
+#### Scenario: Explicit `B` subtype hint is accepted
+- **WHEN** a user reads BAM or SAM with `tag_type_hints=["ML:B:C", "pa:B:i", "pt:i"]`
+- **THEN** the call succeeds without client-side validation errors
+- **AND** the resulting columns use the corresponding logical Polars dtypes when the backend returns those tag values.
+
+#### Scenario: Bare `B` hint is accepted
+- **WHEN** a user reads BAM or SAM with `tag_type_hints=["ML:B"]`
+- **THEN** the call succeeds without client-side validation errors.
+
+### Requirement: Typed optional BAM/SAM tags preserve concrete logical dtypes at the Polars boundary
+
+The system SHALL expose typed optional BAM/SAM tags with concrete logical dtypes instead of collapsing them to generic strings or generic integer lists.
+
+#### Scenario: Standard typed array tags keep their concrete list dtype
+- **WHEN** a user reads BAM or SAM requesting standard tags `ML` and `FZ`
+- **THEN** `ML` is exposed as `list[u8]`
+- **AND** `FZ` is exposed as `list[u16]`.
+
+#### Scenario: Custom scalar and array tags keep their logical types
+- **WHEN** a user reads BAM or SAM requesting typed custom tags such as integer, float, character, hex, string, and `B` array tags
+- **THEN** the resulting Polars columns reflect those logical types rather than falling back to `Utf8` or an undifferentiated integer list.
+
+### Requirement: BAM and SAM write APIs preserve exact tag types for transformed existing tags
+
+`write_bam`, `sink_bam`, `write_sam`, and `sink_sam` SHALL preserve exact SAM tag types for tags that were read from BAM or SAM and then transformed through ordinary Polars operations.
+
+#### Scenario: Existing character tag survives transform and write
+- **WHEN** a user reads a BAM or SAM containing a tag of SAM type `A`, applies a Polars transform such as `filter` or `with_columns`, and writes the result back out
+- **THEN** the written tag keeps SAM type `A`
+- **AND** it is not silently rewritten as `Z`.
+
+#### Scenario: Existing exact array subtype survives transform and write
+- **WHEN** a user reads a BAM or SAM containing a `B`-type tag with a concrete subtype such as `B:C` or `B:S`, applies a Polars transform, and writes the result back out
+- **THEN** the written tag keeps the same concrete array subtype.
+
+### Requirement: BAM and SAM write APIs allow explicit typing for new ambiguous tag columns
+
+`write_bam`, `sink_bam`, `write_sam`, and `sink_sam` SHALL allow callers to supply explicit tag type overrides for new tag columns whose exact SAM type cannot be recovered from Arrow dtype alone.
+
+#### Scenario: New `A` and `H` tags are written with explicit overrides
+- **WHEN** a user creates new BAM/SAM tag columns and calls the write API with `tag_type_overrides={"tp": "A", "XH": "H"}`
+- **THEN** the writer serializes `tp` as SAM type `A`
+- **AND** the writer serializes `XH` as SAM type `H`.
+
+### Requirement: BAM and SAM roundtrips preserve newly added typed tag columns
+
+The system SHALL preserve newly added optional BAM/SAM tag columns across read -> transform -> write -> read-back workflows for both eager and lazy APIs.
+
+#### Scenario: Eager BAM roundtrip with new scalar and array tags
+- **WHEN** a user reads a BAM, adds new scalar and array tag columns, writes the result with `write_bam`, and reads the output back with matching `tag_fields`
+- **THEN** the new tag columns are present in the read-back result
+- **AND** their values and logical dtypes match the written data.
+
+#### Scenario: Lazy BAM sink roundtrip with preserved and new tags
+- **WHEN** a user scans a BAM, preserves existing tag columns, adds new tag columns, writes the result with `sink_bam`, and reads the output back
+- **THEN** both existing and newly added tag columns are present in the read-back result
+- **AND** the tag typing matches the preserved metadata or explicit overrides.

--- a/openspec/changes/add-bam-sam-typed-tag-roundtrip/tasks.md
+++ b/openspec/changes/add-bam-sam-typed-tag-roundtrip/tasks.md
@@ -1,0 +1,55 @@
+# Implementation Tasks
+
+## 1. Dependency alignment
+
+- [x] 1.1 Update all `datafusion-bio-format-*` git dependencies in `Cargo.toml` to a revision that includes `datafusion-bio-formats#170`.
+- [x] 1.2 Refresh `Cargo.lock` after the dependency update.
+- [x] 1.3 Record in the implementation notes whether the final pin is the merged upstream commit or the temporary PR head SHA `95787c8be9cbb8137a72b094161978f3213ac0e4`.
+
+## 2. Python read-side validation and metadata plumbing
+
+- [x] 2.1 Extend `_VALID_SAM_TYPE_CODES` and `_validate_tag_type_hints()` in `polars_bio/io.py` to accept `B`-type hints and exact array subtype grammar.
+- [x] 2.2 Apply the same validation behavior to BAM/SAM SQL entry points in `polars_bio/sql.py`.
+- [x] 2.3 Update BAM/SAM metadata extraction in `polars_bio/metadata_extractors.py` so exact tag type strings are captured from field metadata into BAM/SAM `source_header`.
+- [x] 2.4 Extend `polars_bio/_metadata.py` and related helpers as needed so BAM/SAM `tag_types` metadata survives representative `DataFrame` and `LazyFrame` transformations.
+- [x] 2.5 Update BAM/SAM read docstrings to document scalar hints, `B` hints, and standard examples such as `ML:B:C` and `FZ:B:S`.
+
+## 3. Write API and Rust write-path changes
+
+- [x] 3.1 Add optional `tag_type_overrides` parameters to `write_bam`, `sink_bam`, `write_sam`, and `sink_sam` in `polars_bio/io.py`.
+- [x] 3.2 Validate write-time overrides in Python using the same exact type grammar accepted by the read APIs.
+- [x] 3.3 Extend Rust write options in `src/option.rs` and the Python/Rust bridge so serialized override maps reach the BAM/SAM write path.
+- [x] 3.4 Update `_write_bam_file()` to pass preserved BAM/SAM tag type metadata and explicit overrides into the writer.
+- [x] 3.5 Update `src/write.rs` so `add_bam_tag_metadata()` resolves exact tag types in the order: explicit overrides -> preserved source metadata -> existing field metadata -> Arrow dtype inference.
+- [x] 3.6 Infer exact `B` subtype strings from list element dtypes when no explicit metadata exists.
+- [x] 3.7 Keep default behavior for unannotated string tags as `Z`, while allowing `A` and `H` only when metadata or overrides specify them.
+
+## 4. Unit tests
+
+- [x] 4.1 Add validator tests for accepted and rejected `tag_type_hints` / `tag_type_overrides` grammar.
+- [x] 4.2 Add metadata tests confirming BAM/SAM `tag_types` are present on reads and survive `with_columns`, `filter`, and `select` on both eager and lazy objects.
+- [x] 4.3 Add focused tests for write-time precedence between explicit overrides, preserved metadata, and dtype inference where practical.
+
+## 5. End-to-end integration tests
+
+- [x] 5.1 Extend `tests/test_custom_tag_inference.py` with read-side coverage for exact `B` hints and expected Polars dtypes for custom scalar and array tags.
+- [x] 5.2 Add eager BAM roundtrip tests in `tests/test_io_bam.py` for `read_bam -> add custom tags -> write_bam -> read_bam`.
+- [x] 5.3 Add lazy BAM roundtrip tests in `tests/test_io_bam.py` for `scan_bam -> add custom tags -> sink_bam -> read_bam`.
+- [x] 5.4 Cover mixed scenarios that preserve existing tags while adding new scalar and array tags.
+- [x] 5.5 Cover wide Arrow numeric widths (`Int8`, `Int16`, `Int32`, `Int64`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Float32`, `Float64`) on write for supported SAM integer/float tags.
+- [x] 5.6 Add regression coverage for transformed existing `A` and `H` tags so they do not silently degrade to `Z` on write.
+- [x] 5.7 Add regression coverage for newly created `A` and `H` tags written via `tag_type_overrides`.
+- [x] 5.8 Add BAM-only assertions for `CG` when a fixture is available, and keep SAM roundtrip assertions independent of `CG`.
+- [x] 5.9 Add tests for standard typed array tags `ML -> list[u8]` and `FZ -> list[u16]`, generating a temporary fixture with `pysam` if existing assets do not contain them.
+
+## 6. Documentation and validation
+
+- [x] 6.1 Update user-facing BAM/SAM docs and docstrings with examples for typed custom tag reads and writes.
+- [x] 6.2 Document the semantics and precedence of `tag_type_overrides`.
+- [x] 6.3 Run targeted test coverage for BAM/SAM tag reads and writes.
+- [x] 6.4 Run `openspec validate add-bam-sam-typed-tag-roundtrip --strict`.
+
+## Implementation Notes
+
+- Final `datafusion-bio-format-*` pin: temporary upstream PR head SHA `95787c8be9cbb8137a72b094161978f3213ac0e4` from `datafusion-bio-formats#170`.
+- No `CG` fixture was available locally, so BAM-only `CG` assertions remain deferred; SAM roundtrip coverage was kept independent of `CG`.

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -68,29 +68,81 @@ _FORMAT_COLUMN_TYPES = {
     "Pairs": (PAIRS_STRING_COLUMNS, PAIRS_UINT32_COLUMNS, PAIRS_FLOAT32_COLUMNS),
 }
 
-_VALID_SAM_TYPE_CODES = {"i", "f", "Z", "A", "H"}
+_VALID_SAM_SCALAR_TYPE_CODES = {"A", "c", "C", "s", "S", "i", "I", "f", "Z", "H"}
+_VALID_SAM_ARRAY_SUBTYPE_CODES = {"c", "C", "s", "S", "i", "I", "f"}
+_VALID_SAM_TYPE_CODES = _VALID_SAM_SCALAR_TYPE_CODES | {"B"}
+
+
+def _supported_sam_type_message() -> str:
+    return (
+        "Supported scalar types: A, c, C, s, S, i, I, f, Z, H. "
+        "Array types: B or B:<subtype> where subtype is one of c, C, s, S, i, I, f."
+    )
+
+
+def _validate_tag_name(tag: str, parameter_name: str, raw_value: str) -> None:
+    if len(tag) != 2:
+        raise ValueError(
+            f"Invalid {parameter_name} '{raw_value}': TAG must be exactly 2 characters."
+        )
+
+
+def _validate_sam_type_spec(
+    type_spec: str,
+    parameter_name: str,
+    raw_value: str,
+) -> None:
+    parts = type_spec.split(":")
+
+    if len(parts) == 1:
+        type_code = parts[0]
+        if type_code not in _VALID_SAM_TYPE_CODES:
+            raise ValueError(
+                f"Invalid {parameter_name} '{raw_value}': unsupported SAM type "
+                f"'{type_code}'. {_supported_sam_type_message()}"
+            )
+        return
+
+    if len(parts) == 2 and parts[0] == "B":
+        subtype = parts[1]
+        if subtype in _VALID_SAM_ARRAY_SUBTYPE_CODES:
+            return
+        raise ValueError(
+            f"Invalid {parameter_name} '{raw_value}': unsupported SAM array subtype "
+            f"'{subtype}'. {_supported_sam_type_message()}"
+        )
+
+    raise ValueError(
+        f"Invalid {parameter_name} '{raw_value}': expected scalar TYPE, 'B', or "
+        f"'B:SUBTYPE'. {_supported_sam_type_message()}"
+    )
 
 
 def _validate_tag_type_hints(tag_type_hints: list[str]) -> None:
     """Validate tag_type_hints format before passing to Rust.
 
-    Each hint must be 'TAG:TYPE' where TYPE is one of {i, f, Z, A, H}.
+    Each hint must be one of:
+    - TAG:TYPE
+    - TAG:B
+    - TAG:B:SUBTYPE
     """
     for hint in tag_type_hints:
         parts = hint.split(":")
-        if len(parts) != 2 or len(parts[0]) != 2 or not parts[1]:
+        if len(parts) not in (2, 3) or not parts[0]:
             raise ValueError(
-                f"Invalid tag_type_hint '{hint}': expected 'TAG:TYPE' format "
-                f"where TAG is exactly 2 characters (e.g., 'pt:i', 'de:f'). "
-                f"Valid type codes: {sorted(_VALID_SAM_TYPE_CODES)}"
+                f"Invalid tag_type_hint '{hint}': expected 'TAG:TYPE', 'TAG:B', "
+                f"or 'TAG:B:SUBTYPE' format. {_supported_sam_type_message()}"
             )
-        type_code = parts[1]
-        if type_code not in _VALID_SAM_TYPE_CODES:
-            raise ValueError(
-                f"Invalid type code '{type_code}' in tag_type_hint '{hint}'. "
-                f"Valid type codes: {sorted(_VALID_SAM_TYPE_CODES)} "
-                f"(i=Int32, f=Float32, Z=String, A=String(char), H=String(hex))"
-            )
+        tag = parts[0]
+        _validate_tag_name(tag, "tag_type_hint", hint)
+        _validate_sam_type_spec(":".join(parts[1:]), "tag_type_hint", hint)
+
+
+def _validate_tag_type_overrides(tag_type_overrides: Dict[str, str]) -> None:
+    """Validate BAM/SAM write-time tag type overrides."""
+    for tag, type_spec in tag_type_overrides.items():
+        _validate_tag_name(tag, "tag_type_override", f"{tag}={type_spec}")
+        _validate_sam_type_spec(type_spec, "tag_type_override", f"{tag}={type_spec}")
 
 
 SCHEMAS = {
@@ -742,7 +794,7 @@ class IOOperations:
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration `datafusion.bio.coordinate_system_zero_based`.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags. This prevents integer tags from being decoded as ASCII characters.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Type codes: i=Int32, f=Float32, Z=String, A=String(char), H=String(hex).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format. Use `use_zero_based=True` or set `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` for 0-based half-open coordinates.
@@ -811,7 +863,7 @@ class IOOperations:
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration `datafusion.bio.coordinate_system_zero_based`.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags. This prevents integer tags from being decoded as ASCII characters.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Type codes: i=Int32, f=Float32, Z=String, A=String(char), H=String(hex).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format. Use `use_zero_based=True` or set `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` for 0-based half-open coordinates.
@@ -889,7 +941,7 @@ class IOOperations:
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration `datafusion.bio.coordinate_system_zero_based`.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags. This prevents integer tags from being decoded as ASCII characters.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Type codes: i=Int32, f=Float32, Z=String, A=String(char), H=String(hex).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format. Use `use_zero_based=True` or set `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` for 0-based half-open coordinates.
@@ -1022,7 +1074,7 @@ class IOOperations:
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration `datafusion.bio.coordinate_system_zero_based`.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags. This prevents integer tags from being decoded as ASCII characters.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Type codes: i=Int32, f=Float32, Z=String, A=String(char), H=String(hex).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Used as fallback when inference is disabled or a tag is not found in sampled records. Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format. Use `use_zero_based=True` or set `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` for 0-based half-open coordinates.
@@ -1914,6 +1966,7 @@ class IOOperations:
         df: Union[pl.DataFrame, pl.LazyFrame],
         path: str,
         sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
     ) -> int:
         """
         Write a DataFrame to BAM/SAM format.
@@ -1929,6 +1982,9 @@ class IOOperations:
             path: Output file path (.bam or .sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag type specifications for ambiguous
+                or newly created tag columns, e.g. {"tp": "A", "XH": "H", "ML": "B:C"}.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         Returns:
             Number of rows written
@@ -1942,7 +1998,12 @@ class IOOperations:
             ```
         """
         return _write_bam_file(
-            df, path, OutputFormat.Bam, None, sort_on_write=sort_on_write
+            df,
+            path,
+            OutputFormat.Bam,
+            None,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
         )
 
     @staticmethod
@@ -1950,6 +2011,7 @@ class IOOperations:
         lf: pl.LazyFrame,
         path: str,
         sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
     ) -> None:
         """
         Streaming write a LazyFrame to BAM/SAM format.
@@ -1961,6 +2023,9 @@ class IOOperations:
             path: Output file path (.bam or .sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag type specifications for ambiguous
+                or newly created tag columns, e.g. {"tp": "A", "XH": "H", "ML": "B:C"}.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         !!! Example "Streaming write BAM"
             ```python
@@ -1969,7 +2034,14 @@ class IOOperations:
             pb.sink_bam(lf, "filtered.bam")
             ```
         """
-        _write_bam_file(lf, path, OutputFormat.Bam, None, sort_on_write=sort_on_write)
+        _write_bam_file(
+            lf,
+            path,
+            OutputFormat.Bam,
+            None,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
     @staticmethod
     def read_sam(
@@ -1998,7 +2070,7 @@ class IOOperations:
                 If None (default), uses the global configuration.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format.
@@ -2045,7 +2117,7 @@ class IOOperations:
                 If None (default), uses the global configuration.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! note
             By default, coordinates are output in **1-based closed** format.
@@ -2107,6 +2179,7 @@ class IOOperations:
         df: Union[pl.DataFrame, pl.LazyFrame],
         path: str,
         sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
     ) -> int:
         """
         Write a DataFrame to SAM format (plain text).
@@ -2116,6 +2189,9 @@ class IOOperations:
             path: Output file path (.sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag type specifications for ambiguous
+                or newly created tag columns, e.g. {"tp": "A", "XH": "H", "ML": "B:C"}.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         Returns:
             Number of rows written
@@ -2128,7 +2204,12 @@ class IOOperations:
             ```
         """
         return _write_bam_file(
-            df, path, OutputFormat.Sam, None, sort_on_write=sort_on_write
+            df,
+            path,
+            OutputFormat.Sam,
+            None,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
         )
 
     @staticmethod
@@ -2136,6 +2217,7 @@ class IOOperations:
         lf: pl.LazyFrame,
         path: str,
         sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
     ) -> None:
         """
         Streaming write a LazyFrame to SAM format (plain text).
@@ -2145,6 +2227,9 @@ class IOOperations:
             path: Output file path (.sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag type specifications for ambiguous
+                or newly created tag columns, e.g. {"tp": "A", "XH": "H", "ML": "B:C"}.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         !!! Example "Streaming write SAM"
             ```python
@@ -2153,7 +2238,14 @@ class IOOperations:
             pb.sink_sam(lf, "filtered.sam")
             ```
         """
-        _write_bam_file(lf, path, OutputFormat.Sam, None, sort_on_write=sort_on_write)
+        _write_bam_file(
+            lf,
+            path,
+            OutputFormat.Sam,
+            None,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
     @staticmethod
     def write_cram(
@@ -2358,6 +2450,7 @@ def _write_bam_file(
     output_format: OutputFormat,
     reference_path: Optional[str] = None,
     sort_on_write: bool = False,
+    tag_type_overrides: Optional[Dict[str, str]] = None,
 ) -> int:
     """Internal helper for BAM/CRAM write with streaming."""
     import json
@@ -2384,6 +2477,13 @@ def _write_bam_file(
     if zero_based is None:
         zero_based = _resolve_zero_based(None)
 
+    if tag_type_overrides is not None:
+        _validate_tag_type_overrides(tag_type_overrides)
+
+    tag_type_overrides_json = (
+        json.dumps(tag_type_overrides) if tag_type_overrides else None
+    )
+
     # Build write options
     if output_format == OutputFormat.Cram:
         # reference_path is optional - None means reference-free CRAM
@@ -2393,6 +2493,7 @@ def _write_bam_file(
             tag_fields=None,
             header_metadata=json.dumps(bam_header) if bam_header else None,
             sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides_json,
         )
         write_options = WriteOptions(cram_write_options=cram_opts)
     else:
@@ -2401,6 +2502,7 @@ def _write_bam_file(
             tag_fields=None,
             header_metadata=json.dumps(bam_header) if bam_header else None,
             sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides_json,
         )
         write_options = WriteOptions(bam_write_options=bam_opts)
 

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -138,6 +138,28 @@ def _validate_tag_type_hints(tag_type_hints: list[str]) -> None:
         _validate_sam_type_spec(":".join(parts[1:]), "tag_type_hint", hint)
 
 
+def _normalize_read_tag_type_hints(
+    tag_type_hints: Optional[list[str]],
+) -> Optional[list[str]]:
+    """Normalize read-side hints to the stricter upstream parser contract.
+
+    Upstream now requires array hints to include a subtype (`TAG:B:<subtype>`),
+    but polars-bio intentionally keeps accepting bare `TAG:B` as the default
+    integer-array hint for backward compatibility. Rewrite those hints to
+    `TAG:B:i` before they reach the Rust table providers.
+    """
+    if tag_type_hints is None:
+        return None
+
+    normalized_hints = []
+    for hint in tag_type_hints:
+        if hint.endswith(":B") and hint.count(":") == 1:
+            normalized_hints.append(f"{hint}:i")
+        else:
+            normalized_hints.append(hint)
+    return normalized_hints
+
+
 def _validate_tag_type_overrides(tag_type_overrides: Dict[str, str]) -> None:
     """Validate BAM/SAM write-time tag type overrides."""
     for tag, type_spec in tag_type_overrides.items():
@@ -881,6 +903,7 @@ class IOOperations:
         zero_based = _resolve_zero_based(use_zero_based)
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         bam_read_options = BamReadOptions(
             object_storage_options=object_storage_options,
             zero_based=zero_based,
@@ -1161,6 +1184,7 @@ class IOOperations:
         zero_based = _resolve_zero_based(use_zero_based)
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         cram_read_options = CramReadOptions(
             reference_path=reference_path,
             object_storage_options=object_storage_options,
@@ -2125,6 +2149,7 @@ class IOOperations:
         zero_based = _resolve_zero_based(use_zero_based)
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         bam_read_options = BamReadOptions(
             zero_based=zero_based,
             tag_fields=tag_fields,

--- a/polars_bio/metadata_extractors.py
+++ b/polars_bio/metadata_extractors.py
@@ -330,6 +330,19 @@ def _extract_bam_specific_metadata(
             clean_key = key.replace("bio.bam.", "")
             bam_meta[clean_key] = value
 
+    tag_types = {}
+    for field_name, metadata in field_meta.items():
+        tag_type = metadata.get("bio.bam.tag.type")
+        if not tag_type:
+            continue
+
+        tag_name = metadata.get("bio.bam.tag.tag", field_name)
+        if isinstance(tag_name, str) and len(tag_name) == 2:
+            tag_types[tag_name] = tag_type
+
+    if tag_types:
+        bam_meta["tag_types"] = tag_types
+
     return bam_meta
 
 

--- a/polars_bio/polars_ext.py
+++ b/polars_bio/polars_ext.py
@@ -381,7 +381,12 @@ class PolarsRangesOperations:
         """
         pb.sink_fastq(self._ldf, path)
 
-    def sink_bam(self, path: str, sort_on_write: bool = False) -> None:
+    def sink_bam(
+        self,
+        path: str,
+        sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
+    ) -> None:
         """
         Streaming write LazyFrame to BAM/SAM format.
 
@@ -391,6 +396,9 @@ class PolarsRangesOperations:
             path: Output file path (.bam or .sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag types for newly created or ambiguous
+                tags, for example `{"XA": "A", "XH": "H", "ML": "B:C"}`.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         !!! Example
             ```python
@@ -400,9 +408,19 @@ class PolarsRangesOperations:
             lf.pb.sink_bam("filtered.bam")
             ```
         """
-        pb.sink_bam(self._ldf, path, sort_on_write=sort_on_write)
+        pb.sink_bam(
+            self._ldf,
+            path,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
-    def sink_sam(self, path: str, sort_on_write: bool = False) -> None:
+    def sink_sam(
+        self,
+        path: str,
+        sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
+    ) -> None:
         """
         Streaming write LazyFrame to SAM format (plain text).
 
@@ -410,6 +428,9 @@ class PolarsRangesOperations:
             path: Output file path (.sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag types for newly created or ambiguous
+                tags, for example `{"XA": "A", "XH": "H", "ML": "B:C"}`.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         !!! Example
             ```python
@@ -419,7 +440,12 @@ class PolarsRangesOperations:
             lf.pb.sink_sam("filtered.sam")
             ```
         """
-        pb.sink_sam(self._ldf, path, sort_on_write=sort_on_write)
+        pb.sink_sam(
+            self._ldf,
+            path,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
     def sink_cram(
         self,
@@ -531,7 +557,12 @@ class PolarsDataFrameOperations:
         """
         return pb.write_fastq(self._df, path)
 
-    def write_bam(self, path: str, sort_on_write: bool = False) -> int:
+    def write_bam(
+        self,
+        path: str,
+        sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
+    ) -> int:
         """
         Write DataFrame to BAM/SAM format.
 
@@ -542,6 +573,9 @@ class PolarsDataFrameOperations:
             path: Output file path (.bam or .sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag types for newly created or ambiguous
+                tags, for example `{"XA": "A", "XH": "H", "ML": "B:C"}`.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         Returns:
             The number of rows written.
@@ -554,9 +588,19 @@ class PolarsDataFrameOperations:
             df.pb.write_bam("output.bam")
             ```
         """
-        return pb.write_bam(self._df, path, sort_on_write=sort_on_write)
+        return pb.write_bam(
+            self._df,
+            path,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
-    def write_sam(self, path: str, sort_on_write: bool = False) -> int:
+    def write_sam(
+        self,
+        path: str,
+        sort_on_write: bool = False,
+        tag_type_overrides: Optional[dict[str, str]] = None,
+    ) -> int:
         """
         Write DataFrame to SAM format (plain text).
 
@@ -564,6 +608,9 @@ class PolarsDataFrameOperations:
             path: Output file path (.sam)
             sort_on_write: If True, sort records by (chrom, start) and set header SO:coordinate.
                 If False (default), set header SO:unsorted.
+            tag_type_overrides: Optional exact SAM tag types for newly created or ambiguous
+                tags, for example `{"XA": "A", "XH": "H", "ML": "B:C"}`.
+                Overrides take precedence over preserved source metadata and Arrow dtype inference.
 
         Returns:
             The number of rows written.
@@ -576,7 +623,12 @@ class PolarsDataFrameOperations:
             df.pb.write_sam("output.sam")
             ```
         """
-        return pb.write_sam(self._df, path, sort_on_write=sort_on_write)
+        return pb.write_sam(
+            self._df,
+            path,
+            sort_on_write=sort_on_write,
+            tag_type_overrides=tag_type_overrides,
+        )
 
     def write_cram(
         self,

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -23,7 +23,12 @@ from polars_bio.polars_bio import (
 )
 
 from .context import ctx
-from .io import _cleanse_fields, _lazy_scan, _validate_tag_type_hints
+from .io import (
+    _cleanse_fields,
+    _lazy_scan,
+    _normalize_read_tag_type_hints,
+    _validate_tag_type_hints,
+)
 
 
 class SQL:
@@ -501,6 +506,7 @@ class SQL:
 
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         bam_read_options = BamReadOptions(
             object_storage_options=object_storage_options,
             tag_fields=tag_fields,
@@ -545,6 +551,7 @@ class SQL:
         """
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         bam_read_options = BamReadOptions(
             tag_fields=tag_fields,
             infer_tag_types=infer_tag_types,
@@ -615,6 +622,7 @@ class SQL:
 
         if tag_type_hints is not None:
             _validate_tag_type_hints(tag_type_hints)
+            tag_type_hints = _normalize_read_tag_type_hints(tag_type_hints)
         cram_read_options = CramReadOptions(
             reference_path=None,
             object_storage_options=object_storage_options,

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -458,7 +458,7 @@ class SQL:
             timeout: The timeout in seconds for reading the file from object storage.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
         !!! note
             BAM reader uses **1-based** coordinate system for the `start`, `end`, `mate_start`, `mate_end` columns.
 
@@ -534,7 +534,7 @@ class SQL:
                 If None, no optional tags are parsed (default).
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
 
         !!! Example
             ```python
@@ -594,7 +594,7 @@ class SQL:
             timeout: The timeout in seconds for reading the file from object storage.
             infer_tag_types: If True (default), sample the file to auto-detect types for custom/unknown tags.
             infer_tag_sample_size: Number of records to sample for tag type inference (default: 100).
-            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "de:f"]).
+            tag_type_hints: Explicit SAM-style type hints for tags (e.g., ["pt:i", "ML:B:C", "FZ:B:S"]). Supported forms: TAG:TYPE, TAG:B, or TAG:B:SUBTYPE where TYPE is one of A, c, C, s, S, i, I, f, Z, H and SUBTYPE is one of c, C, s, S, i, I, f.
         !!! note
             CRAM reader uses **1-based** coordinate system for the `start`, `end`, `mate_start`, `mate_end` columns.
 

--- a/src/option.rs
+++ b/src/option.rs
@@ -862,23 +862,27 @@ pub struct BamWriteOptions {
     pub header_metadata: Option<String>,
     #[pyo3(get, set)]
     pub sort_on_write: bool,
+    #[pyo3(get, set)]
+    pub tag_type_overrides: Option<String>,
 }
 
 #[pymethods]
 impl BamWriteOptions {
     #[new]
-    #[pyo3(signature = (zero_based=true, tag_fields=None, header_metadata=None, sort_on_write=false))]
+    #[pyo3(signature = (zero_based=true, tag_fields=None, header_metadata=None, sort_on_write=false, tag_type_overrides=None))]
     pub fn new(
         zero_based: bool,
         tag_fields: Option<Vec<String>>,
         header_metadata: Option<String>,
         sort_on_write: bool,
+        tag_type_overrides: Option<String>,
     ) -> Self {
         BamWriteOptions {
             zero_based,
             tag_fields,
             header_metadata,
             sort_on_write,
+            tag_type_overrides,
         }
     }
 }
@@ -897,18 +901,21 @@ pub struct CramWriteOptions {
     pub header_metadata: Option<String>,
     #[pyo3(get, set)]
     pub sort_on_write: bool,
+    #[pyo3(get, set)]
+    pub tag_type_overrides: Option<String>,
 }
 
 #[pymethods]
 impl CramWriteOptions {
     #[new]
-    #[pyo3(signature = (reference_path=None, zero_based=true, tag_fields=None, header_metadata=None, sort_on_write=false))]
+    #[pyo3(signature = (reference_path=None, zero_based=true, tag_fields=None, header_metadata=None, sort_on_write=false, tag_type_overrides=None))]
     pub fn new(
         reference_path: Option<String>,
         zero_based: bool,
         tag_fields: Option<Vec<String>>,
         header_metadata: Option<String>,
         sort_on_write: bool,
+        tag_type_overrides: Option<String>,
     ) -> Self {
         CramWriteOptions {
             zero_based,
@@ -916,6 +923,7 @@ impl CramWriteOptions {
             tag_fields,
             header_metadata,
             sort_on_write,
+            tag_type_overrides,
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -23,9 +23,10 @@ use datafusion::physical_plan::{
 };
 use datafusion_bio_format_bam::table_provider::BamTableProvider;
 use datafusion_bio_format_core::metadata::{
-    COORDINATE_SYSTEM_METADATA_KEY, VCF_CONTIGS_KEY, VCF_FIELD_DESCRIPTION_KEY,
-    VCF_FIELD_NUMBER_KEY, VCF_FIELD_TYPE_KEY,
+    BAM_TAG_TAG_KEY, BAM_TAG_TYPE_KEY, COORDINATE_SYSTEM_METADATA_KEY, VCF_CONTIGS_KEY,
+    VCF_FIELD_DESCRIPTION_KEY, VCF_FIELD_NUMBER_KEY, VCF_FIELD_TYPE_KEY,
 };
+use datafusion_bio_format_core::tag_registry::format_sam_tag_type;
 use datafusion_bio_format_cram::table_provider::CramTableProvider;
 use datafusion_bio_format_fasta::table_provider::FastaTableProvider;
 use datafusion_bio_format_fastq::table_provider::FastqTableProvider;
@@ -935,7 +936,7 @@ async fn write_bam_streaming(
     path: &str,
     write_options: Option<WriteOptions>,
 ) -> Result<u64, DataFusionError> {
-    let (zero_based, tag_fields, header_metadata, sort_on_write) =
+    let (zero_based, tag_fields, header_metadata, sort_on_write, tag_type_overrides) =
         if let Some(opts) = &write_options {
             if let Some(bam_opts) = &opts.bam_write_options {
                 (
@@ -943,12 +944,13 @@ async fn write_bam_streaming(
                     bam_opts.tag_fields.clone(),
                     bam_opts.header_metadata.clone(),
                     bam_opts.sort_on_write,
+                    bam_opts.tag_type_overrides.clone(),
                 )
             } else {
-                (true, None, None, false)
+                (true, None, None, false, None)
             }
         } else {
-            (true, None, None, false)
+            (true, None, None, false, None)
         };
 
     execute_bam_streaming_write(
@@ -959,6 +961,7 @@ async fn write_bam_streaming(
         tag_fields,
         header_metadata,
         sort_on_write,
+        tag_type_overrides,
     )
     .await
 }
@@ -972,21 +975,26 @@ async fn execute_bam_streaming_write(
     tag_fields: Option<Vec<String>>,
     header_metadata: Option<String>,
     sort_on_write: bool,
+    tag_type_overrides: Option<String>,
 ) -> Result<u64, DataFusionError> {
     let schema = df.schema().inner().clone();
+    let preserved_tag_types = extract_tag_types_from_header_metadata(&header_metadata);
+    let tag_type_overrides = parse_tag_type_overrides_json(&tag_type_overrides)?;
 
     // Auto-detect tag fields if not specified
     let tags = tag_fields.unwrap_or_else(|| extract_tag_fields_from_schema(&schema));
 
     info!(
-        "BAM write: zero_based={}, tags={:?}, header_metadata={:?}",
+        "BAM write: zero_based={}, tags={:?}, header_metadata={:?}, tag_type_overrides={}",
         zero_based,
         tags,
-        header_metadata.as_ref().map(|_| "present")
+        header_metadata.as_ref().map(|_| "present"),
+        !tag_type_overrides.is_empty()
     );
 
     // Add BAM tag metadata to schema (required for serialization)
-    let schema_with_metadata = add_bam_tag_metadata(schema, &tags);
+    let schema_with_metadata =
+        add_bam_tag_metadata(schema, &tags, &preserved_tag_types, &tag_type_overrides);
 
     // Merge header metadata (reference sequences, read groups, programs, etc.) into schema
     let schema_with_metadata = merge_header_metadata(schema_with_metadata, &header_metadata);
@@ -1017,24 +1025,31 @@ async fn write_cram_streaming(
     path: &str,
     write_options: Option<WriteOptions>,
 ) -> Result<u64, DataFusionError> {
-    let (zero_based, reference_path, tag_fields, header_metadata, sort_on_write) =
-        if let Some(opts) = &write_options {
-            if let Some(cram_opts) = &opts.cram_write_options {
-                (
-                    cram_opts.zero_based,
-                    cram_opts.reference_path.clone(),
-                    cram_opts.tag_fields.clone(),
-                    cram_opts.header_metadata.clone(),
-                    cram_opts.sort_on_write,
-                )
-            } else {
-                // Default: no reference (reference-free CRAM)
-                (true, None, None, None, false)
-            }
+    let (
+        zero_based,
+        reference_path,
+        tag_fields,
+        header_metadata,
+        sort_on_write,
+        tag_type_overrides,
+    ) = if let Some(opts) = &write_options {
+        if let Some(cram_opts) = &opts.cram_write_options {
+            (
+                cram_opts.zero_based,
+                cram_opts.reference_path.clone(),
+                cram_opts.tag_fields.clone(),
+                cram_opts.header_metadata.clone(),
+                cram_opts.sort_on_write,
+                cram_opts.tag_type_overrides.clone(),
+            )
         } else {
             // Default: no reference (reference-free CRAM)
-            (true, None, None, None, false)
-        };
+            (true, None, None, None, false, None)
+        }
+    } else {
+        // Default: no reference (reference-free CRAM)
+        (true, None, None, None, false, None)
+    };
 
     execute_cram_streaming_write(
         ctx,
@@ -1045,6 +1060,7 @@ async fn write_cram_streaming(
         tag_fields,
         header_metadata,
         sort_on_write,
+        tag_type_overrides,
     )
     .await
 }
@@ -1059,20 +1075,25 @@ async fn execute_cram_streaming_write(
     tag_fields: Option<Vec<String>>,
     header_metadata: Option<String>,
     sort_on_write: bool,
+    tag_type_overrides: Option<String>,
 ) -> Result<u64, DataFusionError> {
     let schema = df.schema().inner().clone();
+    let preserved_tag_types = extract_tag_types_from_header_metadata(&header_metadata);
+    let tag_type_overrides = parse_tag_type_overrides_json(&tag_type_overrides)?;
     let tags = tag_fields.unwrap_or_else(|| extract_tag_fields_from_schema(&schema));
 
     info!(
-        "CRAM write: zero_based={}, reference={:?}, tags={:?}, header_metadata={:?}",
+        "CRAM write: zero_based={}, reference={:?}, tags={:?}, header_metadata={:?}, tag_type_overrides={}",
         zero_based,
         reference_path,
         tags,
-        header_metadata.as_ref().map(|_| "present")
+        header_metadata.as_ref().map(|_| "present"),
+        !tag_type_overrides.is_empty()
     );
 
     // Add BAM tag metadata to schema (required for serialization)
-    let schema_with_metadata = add_bam_tag_metadata(schema, &tags);
+    let schema_with_metadata =
+        add_bam_tag_metadata(schema, &tags, &preserved_tag_types, &tag_type_overrides);
 
     // Merge header metadata (reference sequences, read groups, programs, etc.) into schema
     let schema_with_metadata = merge_header_metadata(schema_with_metadata, &header_metadata);
@@ -1153,6 +1174,8 @@ fn merge_header_metadata(schema: SchemaRef, header_metadata: &Option<String>) ->
     let key_mapping = [
         ("file_format_version", "bio.bam.file_format_version"),
         ("sort_order", "bio.bam.sort_order"),
+        ("group_order", "bio.bam.group_order"),
+        ("subsort_order", "bio.bam.subsort_order"),
         ("reference_sequences", "bio.bam.reference_sequences"),
         ("read_groups", "bio.bam.read_groups"),
         ("program_info", "bio.bam.program_info"),
@@ -1197,40 +1220,149 @@ fn add_coordinate_system_metadata(schema: SchemaRef, zero_based: bool) -> Schema
     ))
 }
 
-fn add_bam_tag_metadata(schema: SchemaRef, tag_fields: &[String]) -> SchemaRef {
-    use datafusion_bio_format_core::{BAM_TAG_TAG_KEY, BAM_TAG_TYPE_KEY};
-    use std::collections::HashMap;
+fn extract_tag_types_from_header_metadata(
+    header_metadata: &Option<String>,
+) -> HashMap<String, String> {
+    let header_json = match header_metadata {
+        Some(json) if !json.is_empty() && json != "null" => json,
+        _ => return HashMap::new(),
+    };
 
+    let parsed: serde_json::Value = match serde_json::from_str(header_json) {
+        Ok(v) => v,
+        Err(_) => return HashMap::new(),
+    };
+
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => return HashMap::new(),
+    };
+
+    let tag_types = match obj.get("tag_types") {
+        Some(value) => value,
+        None => return HashMap::new(),
+    };
+
+    parse_string_map_json_value(tag_types).unwrap_or_default()
+}
+
+fn parse_tag_type_overrides_json(
+    tag_type_overrides: &Option<String>,
+) -> Result<HashMap<String, String>, DataFusionError> {
+    let overrides_json = match tag_type_overrides {
+        Some(json) if !json.is_empty() && json != "null" => json,
+        _ => return Ok(HashMap::new()),
+    };
+
+    let parsed: serde_json::Value = serde_json::from_str(overrides_json).map_err(|e| {
+        DataFusionError::Internal(format!("Failed to parse tag_type_overrides JSON: {e}"))
+    })?;
+
+    parse_string_map_json_value(&parsed).ok_or_else(|| {
+        DataFusionError::Internal(
+            "tag_type_overrides must be a JSON object with string values".to_string(),
+        )
+    })
+}
+
+fn parse_string_map_json_value(value: &serde_json::Value) -> Option<HashMap<String, String>> {
+    match value {
+        serde_json::Value::Object(obj) => obj
+            .iter()
+            .map(|(key, value)| value.as_str().map(|v| (key.clone(), v.to_string())))
+            .collect(),
+        serde_json::Value::String(json) => {
+            let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
+            parse_string_map_json_value(&parsed)
+        },
+        _ => None,
+    }
+}
+
+fn infer_bam_scalar_tag_type(data_type: &DataType) -> String {
+    match data_type {
+        DataType::Int8 => "c".to_string(),
+        DataType::UInt8 => "C".to_string(),
+        DataType::Int16 => "s".to_string(),
+        DataType::UInt16 => "S".to_string(),
+        DataType::Int32 | DataType::Int64 => "i".to_string(),
+        DataType::UInt32 | DataType::UInt64 => "I".to_string(),
+        DataType::Float32 | DataType::Float64 => "f".to_string(),
+        DataType::Utf8 | DataType::LargeUtf8 => "Z".to_string(),
+        _ => "Z".to_string(),
+    }
+}
+
+fn normalize_bam_array_data_type(data_type: &DataType) -> Option<DataType> {
+    let (field, nullable) = match data_type {
+        DataType::List(field) | DataType::LargeList(field) => (field.as_ref(), field.is_nullable()),
+        DataType::FixedSizeList(field, _) => (field.as_ref(), field.is_nullable()),
+        _ => return None,
+    };
+
+    let normalized_inner = match field.data_type() {
+        DataType::Int8 => DataType::Int8,
+        DataType::UInt8 => DataType::UInt8,
+        DataType::Int16 => DataType::Int16,
+        DataType::UInt16 => DataType::UInt16,
+        DataType::Int32 | DataType::Int64 => DataType::Int32,
+        DataType::UInt32 | DataType::UInt64 => DataType::UInt32,
+        DataType::Float32 | DataType::Float64 => DataType::Float32,
+        _ => return None,
+    };
+
+    Some(DataType::List(Arc::new(Field::new(
+        field.name(),
+        normalized_inner,
+        nullable,
+    ))))
+}
+
+fn infer_bam_tag_type(data_type: &DataType) -> String {
+    if let Some(normalized_array_type) = normalize_bam_array_data_type(data_type) {
+        return format_sam_tag_type('B', &normalized_array_type);
+    }
+
+    infer_bam_scalar_tag_type(data_type)
+}
+
+fn normalize_bam_write_data_type(data_type: &DataType) -> DataType {
+    normalize_bam_array_data_type(data_type).unwrap_or_else(|| data_type.clone())
+}
+
+fn add_bam_tag_metadata(
+    schema: SchemaRef,
+    tag_fields: &[String],
+    preserved_tag_types: &HashMap<String, String>,
+    tag_type_overrides: &HashMap<String, String>,
+) -> SchemaRef {
     let mut new_fields = Vec::new();
     let tag_set: std::collections::HashSet<&str> = tag_fields.iter().map(|s| s.as_str()).collect();
 
     for field in schema.fields().iter() {
         if tag_set.contains(field.name().as_str()) {
-            // This is a tag field - add metadata
-            // First check if the field already has BAM_TAG_TYPE_KEY metadata (preserve existing)
-            let sam_type = if let Some(existing_type) = field.metadata().get(BAM_TAG_TYPE_KEY) {
-                // Preserve existing tag type metadata (e.g., from read_bam)
-                existing_type.chars().next().unwrap_or('Z')
+            let sam_type = tag_type_overrides
+                .get(field.name())
+                .cloned()
+                .or_else(|| preserved_tag_types.get(field.name()).cloned())
+                .or_else(|| field.metadata().get(BAM_TAG_TYPE_KEY).cloned())
+                .unwrap_or_else(|| infer_bam_tag_type(field.data_type()));
+
+            let mut field_metadata = field.metadata().clone();
+            if field_metadata.is_empty() {
+                field_metadata = HashMap::new();
+            }
+            field_metadata.insert(BAM_TAG_TYPE_KEY.to_string(), sam_type);
+            field_metadata.insert(BAM_TAG_TAG_KEY.to_string(), field.name().clone());
+            let normalized_data_type = normalize_bam_write_data_type(field.data_type());
+            let new_field = if normalized_data_type == *field.data_type() {
+                field.as_ref().clone().with_metadata(field_metadata)
             } else {
-                // Infer SAM type from Arrow data type
-                match field.data_type() {
-                    DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => 'i',
-                    DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => 'i',
-                    DataType::Float32 | DataType::Float64 => 'f',
-                    DataType::Utf8 | DataType::LargeUtf8 => 'Z',
-                    // Handle array/list types for BAM 'B' tags (integer/byte arrays)
-                    DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
-                        'B'
-                    },
-                    _ => 'Z', // Default to string for unknown types
-                }
+                Field::new(field.name(), normalized_data_type, field.is_nullable())
+                    .with_metadata(field_metadata)
             };
 
-            let mut field_metadata = HashMap::new();
-            field_metadata.insert(BAM_TAG_TYPE_KEY.to_string(), sam_type.to_string());
-            field_metadata.insert(BAM_TAG_TAG_KEY.to_string(), field.name().clone());
-
-            new_fields.push(field.as_ref().clone().with_metadata(field_metadata));
+            new_fields.push(new_field);
         } else {
             new_fields.push(field.as_ref().clone());
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1230,7 +1230,10 @@ fn extract_tag_types_from_header_metadata(
 
     let parsed: serde_json::Value = match serde_json::from_str(header_json) {
         Ok(v) => v,
-        Err(_) => return HashMap::new(),
+        Err(e) => {
+            log::debug!("Failed to parse BAM header metadata JSON: {}", e);
+            return HashMap::new();
+        },
     };
 
     let obj = match parsed.as_object() {
@@ -1255,11 +1258,11 @@ fn parse_tag_type_overrides_json(
     };
 
     let parsed: serde_json::Value = serde_json::from_str(overrides_json).map_err(|e| {
-        DataFusionError::Internal(format!("Failed to parse tag_type_overrides JSON: {e}"))
+        DataFusionError::Plan(format!("Failed to parse tag_type_overrides JSON: {e}"))
     })?;
 
     parse_string_map_json_value(&parsed).ok_or_else(|| {
-        DataFusionError::Internal(
+        DataFusionError::Plan(
             "tag_type_overrides must be a JSON object with string values".to_string(),
         )
     })
@@ -1272,6 +1275,9 @@ fn parse_string_map_json_value(value: &serde_json::Value) -> Option<HashMap<Stri
             .map(|(key, value)| value.as_str().map(|v| (key.clone(), v.to_string())))
             .collect(),
         serde_json::Value::String(json) => {
+            // `source_header["tag_types"]` normally arrives as a nested JSON object, but
+            // tolerate double-encoded values from older callers or manually-constructed
+            // header metadata payloads.
             let parsed: serde_json::Value = serde_json::from_str(json).ok()?;
             parse_string_map_json_value(&parsed)
         },
@@ -1349,9 +1355,6 @@ fn add_bam_tag_metadata(
                 .unwrap_or_else(|| infer_bam_tag_type(field.data_type()));
 
             let mut field_metadata = field.metadata().clone();
-            if field_metadata.is_empty() {
-                field_metadata = HashMap::new();
-            }
             field_metadata.insert(BAM_TAG_TYPE_KEY.to_string(), sam_type);
             field_metadata.insert(BAM_TAG_TAG_KEY.to_string(), field.name().clone());
             let normalized_data_type = normalize_bam_write_data_type(field.data_type());
@@ -1394,5 +1397,30 @@ mod tests {
         );
         assert_eq!(parse_format_column_name("chrom"), None);
         assert_eq!(parse_format_column_name("AF"), None); // No sample prefix
+    }
+
+    #[test]
+    fn test_parse_string_map_json_value_accepts_double_encoded_json() {
+        let value = serde_json::Value::String("{\"ML\":\"BC\",\"FZ\":\"BS\"}".to_string());
+
+        assert_eq!(
+            parse_string_map_json_value(&value),
+            Some(HashMap::from([
+                ("ML".to_string(), "BC".to_string()),
+                ("FZ".to_string(), "BS".to_string()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_parse_tag_type_overrides_json_uses_plan_error_for_invalid_input() {
+        let err = parse_tag_type_overrides_json(&Some("[1,2,3]".to_string())).unwrap_err();
+
+        match err {
+            DataFusionError::Plan(message) => {
+                assert!(message.contains("tag_type_overrides must be a JSON object"));
+            },
+            other => panic!("expected DataFusionError::Plan, got {other:?}"),
+        }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,3 +64,53 @@ try:
 except Exception:
     # If Polars isn't importable here, let the tests surface the real error.
     pass
+
+
+@pytest.fixture
+def typed_tag_alignment_paths(tmp_path):
+    """Create a small BAM/SAM fixture with exact scalar and array tag typing."""
+    from array import array
+
+    import pysam
+
+    bam_path = tmp_path / "typed_tags.bam"
+    sam_path = tmp_path / "typed_tags.sam"
+    header = {
+        "HD": {"VN": "1.6", "SO": "coordinate"},
+        "SQ": [{"SN": "chr1", "LN": 1000}],
+    }
+
+    with pysam.AlignmentFile(str(bam_path), "wb", header=header) as bam_out:
+        for index, (char_tag, hex_tag) in enumerate((("A", "0A0B"), ("B", "C0FFEE"))):
+            record = pysam.AlignedSegment()
+            record.query_name = f"typed-read-{index + 1}"
+            record.query_sequence = "ACGTACGT"
+            record.flag = 0
+            record.reference_id = 0
+            record.reference_start = 100 + (index * 10)
+            record.mapping_quality = 60
+            record.cigarstring = "8M"
+            record.next_reference_id = -1
+            record.next_reference_start = -1
+            record.template_length = 0
+            record.query_qualities = pysam.qualitystring_to_array("FFFFFFFF")
+            record.set_tag("XA", char_tag, value_type="A")
+            record.set_tag("XH", hex_tag, value_type="H")
+            record.set_tag("XI", 100 + index, value_type="i")
+            record.set_tag("XF", 1.5 + index, value_type="f")
+            record.set_tag("XZ", f"text-{index}", value_type="Z")
+            record.set_tag("ML", array("B", [1 + index, 2 + index, 3 + index]))
+            record.set_tag("FZ", array("H", [1000 + index, 2000 + index]))
+            record.set_tag("XC", array("b", [-1, 2 + index]))
+            record.set_tag("XS", array("h", [-3, 4 + index]))
+            record.set_tag("XB", array("i", [5 + index, 6 + index]))
+            record.set_tag("XW", array("I", [7 + index, 8 + index]))
+            record.set_tag("XY", array("f", [0.25 + index, 0.5 + index]))
+            bam_out.write(record)
+
+    with pysam.AlignmentFile(str(bam_path), "rb") as bam_in:
+        with pysam.AlignmentFile(str(sam_path), "wh", header=bam_in.header) as sam_out:
+            for record in bam_in:
+                sam_out.write(record)
+
+    return {"bam": str(bam_path), "sam": str(sam_path)}

--- a/tests/test_custom_tag_inference.py
+++ b/tests/test_custom_tag_inference.py
@@ -26,6 +26,7 @@ import pytest
 from _expected import DATA_DIR
 
 import polars_bio as pb
+from polars_bio.io import _validate_tag_type_hints, _validate_tag_type_overrides
 
 NANOPORE_BAM = f"{DATA_DIR}/io/bam/nanopore_custom_tags.bam"
 NANOPORE_CRAM = f"{DATA_DIR}/io/cram/nanopore_custom_tags.cram"
@@ -70,6 +71,61 @@ STRING_TAGS = ["fn", "st", "sv"]
 # Known SAM spec tags
 KNOWN_INT_TAGS = ["NM", "AS"]
 KNOWN_STR_TAGS = ["MD", "RG"]
+
+
+class TestTagTypeValidators:
+    @pytest.mark.parametrize(
+        "tag_type_hints",
+        [
+            ["pt:i", "de:f", "tp:A", "XH:H"],
+            ["ML:B", "ML:B:C", "FZ:B:S", "XC:B:c", "XY:B:f"],
+        ],
+    )
+    def test_validate_tag_type_hints_accepts_scalar_and_array_types(
+        self, tag_type_hints
+    ):
+        _validate_tag_type_hints(tag_type_hints)
+
+    @pytest.mark.parametrize(
+        "tag_type_hints",
+        [
+            ["pt"],
+            ["pt:X:extra"],
+            ["p:i"],
+            ["LONG:i"],
+            ["ML:B:Q"],
+        ],
+    )
+    def test_validate_tag_type_hints_rejects_invalid_specs(self, tag_type_hints):
+        with pytest.raises(ValueError):
+            _validate_tag_type_hints(tag_type_hints)
+
+    @pytest.mark.parametrize(
+        "tag_type_overrides",
+        [
+            {"XA": "A", "XH": "H", "XY": "Z"},
+            {"ML": "B:C", "FZ": "B:S", "XB": "B"},
+        ],
+    )
+    def test_validate_tag_type_overrides_accepts_scalar_and_array_types(
+        self, tag_type_overrides
+    ):
+        _validate_tag_type_overrides(tag_type_overrides)
+
+    @pytest.mark.parametrize(
+        "tag_type_overrides",
+        [
+            {"X": "A"},
+            {"LONG": "Z"},
+            {"XA": "Q"},
+            {"ML": "B:Q"},
+        ],
+    )
+    def test_validate_tag_type_overrides_rejects_invalid_specs(
+        self, tag_type_overrides
+    ):
+        with pytest.raises(ValueError):
+            _validate_tag_type_overrides(tag_type_overrides)
 
 
 @pytest.fixture(scope="module")
@@ -744,3 +800,67 @@ class TestCramRegisterTagInference:
         assert result["NM"].dtype == pl.Int32
         assert result["de"].dtype == pl.Float32
         assert result["MD"].dtype == pl.Utf8
+
+
+class TestTypedArrayTagHints:
+    def test_read_bam_supports_exact_array_hints(self, typed_tag_alignment_paths):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["ML", "FZ"],
+            infer_tag_types=False,
+            tag_type_hints=["ML:B:C", "FZ:B:S"],
+        )
+
+        assert df["ML"].dtype == pl.List(pl.UInt8)
+        assert df["FZ"].dtype == pl.List(pl.UInt16)
+        assert df["ML"].to_list() == [[1, 2, 3], [2, 3, 4]]
+        assert df["FZ"].to_list() == [[1000, 2000], [1001, 2001]]
+
+    def test_read_bam_supports_default_array_hint(self, typed_tag_alignment_paths):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["XB"],
+            infer_tag_types=False,
+            tag_type_hints=["XB:B"],
+        )
+
+        assert df["XB"].dtype == pl.List(pl.Int32)
+        assert df["XB"].to_list() == [[5, 6], [6, 7]]
+
+    def test_read_sam_supports_exact_array_hints(self, typed_tag_alignment_paths):
+        df = pb.read_sam(
+            typed_tag_alignment_paths["sam"],
+            tag_fields=["ML", "FZ"],
+            infer_tag_types=False,
+            tag_type_hints=["ML:B:C", "FZ:B:S"],
+        )
+
+        assert df["ML"].dtype == pl.List(pl.UInt8)
+        assert df["FZ"].dtype == pl.List(pl.UInt16)
+
+    def test_inferred_standard_typed_arrays_round_trip_to_expected_dtypes(
+        self, typed_tag_alignment_paths
+    ):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["ML", "FZ", "XC", "XS", "XB", "XW", "XY"],
+        )
+
+        assert df["ML"].dtype == pl.List(pl.UInt8)
+        assert df["FZ"].dtype == pl.List(pl.UInt16)
+        assert df["XC"].dtype == pl.List(pl.Int8)
+        assert df["XS"].dtype == pl.List(pl.Int16)
+        assert df["XB"].dtype == pl.List(pl.Int32)
+        assert df["XW"].dtype == pl.List(pl.UInt32)
+        assert df["XY"].dtype == pl.List(pl.Float32)
+
+    def test_invalid_array_subtype_hint_raises_before_scan(
+        self, typed_tag_alignment_paths
+    ):
+        with pytest.raises(ValueError):
+            pb.read_bam(
+                typed_tag_alignment_paths["bam"],
+                tag_fields=["ML"],
+                infer_tag_types=False,
+                tag_type_hints=["ML:B:Q"],
+            )

--- a/tests/test_custom_tag_inference.py
+++ b/tests/test_custom_tag_inference.py
@@ -26,7 +26,11 @@ import pytest
 from _expected import DATA_DIR
 
 import polars_bio as pb
-from polars_bio.io import _validate_tag_type_hints, _validate_tag_type_overrides
+from polars_bio.io import (
+    _normalize_read_tag_type_hints,
+    _validate_tag_type_hints,
+    _validate_tag_type_overrides,
+)
 
 NANOPORE_BAM = f"{DATA_DIR}/io/bam/nanopore_custom_tags.bam"
 NANOPORE_CRAM = f"{DATA_DIR}/io/cram/nanopore_custom_tags.cram"
@@ -85,6 +89,13 @@ class TestTagTypeValidators:
         self, tag_type_hints
     ):
         _validate_tag_type_hints(tag_type_hints)
+
+    def test_normalize_read_tag_type_hints_rewrites_default_array_to_int32(self):
+        assert _normalize_read_tag_type_hints(["XB:B", "ML:B:C", "pt:i"]) == [
+            "XB:B:i",
+            "ML:B:C",
+            "pt:i",
+        ]
 
     @pytest.mark.parametrize(
         "tag_type_hints",

--- a/tests/test_io_bam.py
+++ b/tests/test_io_bam.py
@@ -548,16 +548,16 @@ class TestTypedTagMetadataAndRoundtrip:
 
 
 @pytest.mark.parametrize(
-    ("tag_name", "dtype", "value", "expected_type"),
+    ("tag_name", "dtype", "value", "expected_exact_type"),
     [
-        ("C8", pl.Int8, -5, "c"),
-        ("U8", pl.UInt8, 250, "C"),
-        ("C6", pl.Int16, -300, "s"),
-        ("U6", pl.UInt16, 60_000, "S"),
-        ("I3", pl.Int32, 123_456, "i"),
-        ("I6", pl.Int64, 123_456_789, "i"),
-        ("N3", pl.UInt32, 3_000_000_000, "I"),
-        ("N6", pl.UInt64, 3_000_000_000, "I"),
+        ("C8", pl.Int8, -5, None),
+        ("U8", pl.UInt8, 250, None),
+        ("C6", pl.Int16, -300, None),
+        ("U6", pl.UInt16, 60_000, None),
+        ("I3", pl.Int32, 123_456, None),
+        ("I6", pl.Int64, 123_456_789, None),
+        ("N3", pl.UInt32, 3_000_000_000, None),
+        ("N6", pl.UInt64, 3_000_000_000, None),
         ("F3", pl.Float32, 1.25, "f"),
         ("F6", pl.Float64, 2.5, "f"),
     ],
@@ -568,7 +568,7 @@ def test_write_bam_accepts_wide_numeric_widths(
     tag_name,
     dtype,
     value,
-    expected_type,
+    expected_exact_type,
 ):
     df = pb.read_bam(typed_tag_alignment_paths["bam"]).head(1).select(CORE_BAM_COLUMNS)
     df = df.with_columns(pl.Series(tag_name, [value], dtype=dtype))
@@ -581,9 +581,11 @@ def test_write_bam_accepts_wide_numeric_widths(
     ]
     if isinstance(value, float):
         assert roundtrip_value == pytest.approx(value)
-        assert actual_type == expected_type
+        assert actual_type == expected_exact_type
     else:
         assert roundtrip_value == value
+        # Integer tags can roundtrip as any valid SAM integer type because the
+        # upstream writer canonicalizes widths based on the value being encoded.
         assert actual_type in {"c", "C", "s", "S", "i", "I"}
 
 

--- a/tests/test_io_bam.py
+++ b/tests/test_io_bam.py
@@ -9,6 +9,27 @@ from _expected import DATA_DIR
 
 import polars_bio as pb
 
+CORE_BAM_COLUMNS = [
+    "name",
+    "chrom",
+    "start",
+    "end",
+    "flags",
+    "cigar",
+    "mapping_quality",
+    "mate_chrom",
+    "mate_start",
+    "sequence",
+    "quality_scores",
+    "template_length",
+]
+
+
+def _first_record_tag_data(path: str, mode: str, tags: list[str]) -> dict[str, tuple]:
+    with pysam.AlignmentFile(path, mode) as alignment:
+        record = next(alignment)
+        return {tag: record.get_tag(tag, with_value_type=True) for tag in tags}
+
 
 class TestIOBAM:
     df = pb.read_bam(f"{DATA_DIR}/io/bam/test.bam")
@@ -318,6 +339,252 @@ class TestBAMWrite:
 
         df_back = pb.read_bam(str(numeric_output))
         assert len(df_back) == 25
+
+
+class TestTypedTagMetadataAndRoundtrip:
+    EXPECTED_TAG_TYPES = {
+        "XA": "A",
+        "XH": "H",
+        "ML": "B:C",
+        "FZ": "B:S",
+    }
+
+    def _assert_expected_tag_types(self, meta):
+        header = meta.get("header", {})
+        assert "tag_types" in header
+        for tag, expected in self.EXPECTED_TAG_TYPES.items():
+            assert header["tag_types"][tag] == expected
+
+    def test_bam_read_exposes_exact_tag_types_in_metadata(
+        self, typed_tag_alignment_paths
+    ):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["XA", "XH", "ML", "FZ"],
+        )
+
+        self._assert_expected_tag_types(pb.get_metadata(df))
+
+    def test_bam_tag_types_survive_eager_transformations(
+        self, typed_tag_alignment_paths
+    ):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["XA", "XH", "ML", "FZ"],
+        )
+
+        transformed = (
+            df.with_columns(
+                pl.col("XA").alias("XA"),
+                pl.col("ML").alias("ML"),
+            )
+            .filter(pl.col("mapping_quality") > 0)
+            .select(CORE_BAM_COLUMNS + ["XA", "XH", "ML", "FZ"])
+        )
+
+        self._assert_expected_tag_types(pb.get_metadata(transformed))
+
+    def test_bam_tag_types_survive_lazy_transformations(
+        self, typed_tag_alignment_paths
+    ):
+        lf = pb.scan_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["XA", "XH", "ML", "FZ"],
+        )
+
+        transformed = (
+            lf.with_columns(
+                pl.col("XA").alias("XA"),
+                pl.col("ML").alias("ML"),
+            )
+            .filter(pl.col("mapping_quality") > 0)
+            .select(CORE_BAM_COLUMNS + ["XA", "XH", "ML", "FZ"])
+        )
+
+        self._assert_expected_tag_types(pb.get_metadata(transformed))
+
+    def test_write_bam_preserves_existing_exact_tag_types(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        df = (
+            pb.read_bam(
+                typed_tag_alignment_paths["bam"],
+                tag_fields=["XA", "XH", "ML", "FZ"],
+            )
+            .filter(pl.col("mapping_quality") > 0)
+            .select(CORE_BAM_COLUMNS + ["XA", "XH", "ML", "FZ"])
+        )
+
+        out_path = str(tmp_path / "typed_roundtrip.bam")
+        pb.write_bam(df, out_path)
+
+        tag_data = _first_record_tag_data(out_path, "rb", ["XA", "XH", "ML", "FZ"])
+        assert tag_data["XA"] == ("A", "A")
+        assert tag_data["XH"][1] == "H"
+        assert tag_data["ML"][1] == "BC"
+        assert tag_data["FZ"][1] == "BS"
+
+    def test_write_sam_preserves_existing_exact_tag_types(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        df = (
+            pb.read_sam(
+                typed_tag_alignment_paths["sam"],
+                tag_fields=["XA", "XH", "ML", "FZ"],
+            )
+            .filter(pl.col("mapping_quality") > 0)
+            .select(CORE_BAM_COLUMNS + ["XA", "XH", "ML", "FZ"])
+        )
+
+        out_path = str(tmp_path / "typed_roundtrip.sam")
+        pb.write_sam(df, out_path)
+
+        tag_data = _first_record_tag_data(out_path, "r", ["XA", "XH", "ML", "FZ"])
+        assert tag_data["XA"] == ("A", "A")
+        assert tag_data["XH"][1] == "H"
+        assert tag_data["ML"][1] == "BC"
+        assert tag_data["FZ"][1] == "BS"
+
+    def test_write_bam_with_explicit_a_and_h_overrides(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        base = pb.read_bam(typed_tag_alignment_paths["bam"]).select(CORE_BAM_COLUMNS)
+        df = base.with_columns(
+            pl.Series("YA", ["Q", "R"], dtype=pl.Utf8),
+            pl.Series("YH", ["0A0B", "C0FFEE"], dtype=pl.Utf8),
+        )
+
+        out_path = str(tmp_path / "override_tags.bam")
+        pb.write_bam(
+            df,
+            out_path,
+            tag_type_overrides={"YA": "A", "YH": "H"},
+        )
+
+        tag_data = _first_record_tag_data(out_path, "rb", ["YA", "YH"])
+        assert tag_data["YA"] == ("Q", "A")
+        assert tag_data["YH"][1] == "H"
+
+    def test_write_bam_overrides_take_precedence_over_preserved_metadata(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        df = pb.read_bam(
+            typed_tag_alignment_paths["bam"],
+            tag_fields=["XA"],
+        ).select(CORE_BAM_COLUMNS + ["XA"])
+
+        out_path = str(tmp_path / "override_precedence.bam")
+        pb.write_bam(
+            df,
+            out_path,
+            tag_type_overrides={"XA": "Z"},
+        )
+
+        tag_data = _first_record_tag_data(out_path, "rb", ["XA"])
+        assert tag_data["XA"] == ("A", "Z")
+
+    def test_write_bam_roundtrip_with_new_scalar_and_array_tags(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        base = pb.read_bam(typed_tag_alignment_paths["bam"]).select(CORE_BAM_COLUMNS)
+        df = base.with_columns(
+            pl.Series("YI", [10, 20], dtype=pl.Int32),
+            pl.Series("YF", [1.25, 2.5], dtype=pl.Float32),
+            pl.Series("YZ", ["alpha", "beta"], dtype=pl.Utf8),
+            pl.Series("YL", [[1, 2], [3, 4]], dtype=pl.List(pl.UInt8)),
+        )
+
+        out_path = str(tmp_path / "new_tags.bam")
+        pb.write_bam(df, out_path)
+
+        df_back = pb.read_bam(out_path, tag_fields=["YI", "YF", "YZ", "YL"])
+        assert df_back["YI"].to_list() == [10, 20]
+        assert df_back["YF"].to_list() == pytest.approx([1.25, 2.5])
+        assert df_back["YZ"].to_list() == ["alpha", "beta"]
+        assert df_back["YL"].dtype == pl.List(pl.UInt8)
+        assert df_back["YL"].to_list() == [[1, 2], [3, 4]]
+
+        tag_data = _first_record_tag_data(out_path, "rb", ["YI", "YF", "YZ", "YL"])
+        assert tag_data["YI"][1] in {"c", "C", "s", "S", "i", "I"}
+        assert tag_data["YF"][1] == "f"
+        assert tag_data["YZ"][1] == "Z"
+        assert tag_data["YL"][1] == "BC"
+
+    def test_sink_bam_roundtrip_preserves_existing_and_new_typed_tags(
+        self, typed_tag_alignment_paths, tmp_path
+    ):
+        lf = (
+            pb.scan_bam(
+                typed_tag_alignment_paths["bam"],
+                tag_fields=["ML", "FZ"],
+            )
+            .with_columns(
+                pl.lit(42).cast(pl.Int32).alias("YI"),
+                pl.lit(2.5).cast(pl.Float64).alias("YF"),
+                pl.col("ML").alias("YL"),
+            )
+            .select(CORE_BAM_COLUMNS + ["ML", "FZ", "YI", "YF", "YL"])
+        )
+
+        out_path = str(tmp_path / "lazy_typed_tags.bam")
+        pb.sink_bam(lf, out_path)
+
+        df_back = pb.read_bam(out_path, tag_fields=["ML", "FZ", "YI", "YF", "YL"])
+        assert df_back["ML"].dtype == pl.List(pl.UInt8)
+        assert df_back["FZ"].dtype == pl.List(pl.UInt16)
+        assert df_back["YI"].to_list() == [42, 42]
+        assert df_back["YF"].to_list() == pytest.approx([2.5, 2.5])
+        assert df_back["YL"].dtype == pl.List(pl.UInt8)
+        assert df_back["YL"].to_list() == [[1, 2, 3], [2, 3, 4]]
+
+        tag_data = _first_record_tag_data(
+            out_path, "rb", ["ML", "FZ", "YI", "YF", "YL"]
+        )
+        assert tag_data["ML"][1] == "BC"
+        assert tag_data["FZ"][1] == "BS"
+        assert tag_data["YI"][1] in {"c", "C", "s", "S", "i", "I"}
+        assert tag_data["YF"][1] == "f"
+        assert tag_data["YL"][1] == "BC"
+
+
+@pytest.mark.parametrize(
+    ("tag_name", "dtype", "value", "expected_type"),
+    [
+        ("C8", pl.Int8, -5, "c"),
+        ("U8", pl.UInt8, 250, "C"),
+        ("C6", pl.Int16, -300, "s"),
+        ("U6", pl.UInt16, 60_000, "S"),
+        ("I3", pl.Int32, 123_456, "i"),
+        ("I6", pl.Int64, 123_456_789, "i"),
+        ("N3", pl.UInt32, 3_000_000_000, "I"),
+        ("N6", pl.UInt64, 3_000_000_000, "I"),
+        ("F3", pl.Float32, 1.25, "f"),
+        ("F6", pl.Float64, 2.5, "f"),
+    ],
+)
+def test_write_bam_accepts_wide_numeric_widths(
+    typed_tag_alignment_paths,
+    tmp_path,
+    tag_name,
+    dtype,
+    value,
+    expected_type,
+):
+    df = pb.read_bam(typed_tag_alignment_paths["bam"]).head(1).select(CORE_BAM_COLUMNS)
+    df = df.with_columns(pl.Series(tag_name, [value], dtype=dtype))
+
+    out_path = str(tmp_path / f"wide_{tag_name}.bam")
+    pb.write_bam(df, out_path)
+
+    roundtrip_value, actual_type = _first_record_tag_data(out_path, "rb", [tag_name])[
+        tag_name
+    ]
+    if isinstance(value, float):
+        assert roundtrip_value == pytest.approx(value)
+        assert actual_type == expected_type
+    else:
+        assert roundtrip_value == value
+        assert actual_type in {"c", "C", "s", "S", "i", "I"}
 
 
 class TestBAMWritePositionRoundtrip:


### PR DESCRIPTION
## Summary
- pin `datafusion-bio-format-*` to upstream PR head `95787c8be9cbb8137a72b094161978f3213ac0e4`
- accept exact SAM tag hint grammar for BAM/SAM reads, including `B` and `B:subtype`
- preserve exact BAM/SAM tag typing through `source_header["tag_types"]`
- add write-time `tag_type_overrides` for ambiguous or newly created tags
- normalize outgoing BAM/SAM tag schemas so typed arrays round-trip correctly
- add unit and end-to-end coverage for typed arrays, preserved `A`/`H`, explicit overrides, and wide numeric widths

## Validation
- `pytest tests/test_io_bam.py`
- `pytest tests/test_custom_tag_inference.py`
- `pytest tests/test_source_metadata.py`
- `openspec validate add-bam-sam-typed-tag-roundtrip --strict`

## Issues
Closes #362
Closes #363
Closes #364
Closes #365