### PR TITLE
fix: parallelize LazyFrame Arrow C stream inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,8 +1535,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.7.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=f6444d648d7a0eb9008b6f2530d4e6633e5e7296#f6444d648d7a0eb9008b6f2530d4e6633e5e7296"
+version = "0.8.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1549,8 +1549,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-ranges"
-version = "0.7.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=f6444d648d7a0eb9008b6f2530d4e6633e5e7296#f6444d648d7a0eb9008b6f2530d4e6633e5e7296"
+version = "0.8.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5857,8 +5857,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superintervals"
-version = "0.9.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=f6444d648d7a0eb9008b6f2530d4e6633e5e7296#f6444d648d7a0eb9008b6f2530d4e6633e5e7296"
+version = "0.10.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
 dependencies = [
  "aligned-vec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,8 +1535,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.8.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
+version = "0.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1549,8 +1549,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-ranges"
-version = "0.8.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
+version = "0.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5857,8 +5857,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superintervals"
-version = "0.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c248b0317b5e3254b09a015008ff8e05e9f1b065#c248b0317b5e3254b09a015008ff8e05e9f1b065"
+version = "0.10.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
 dependencies = [
  "aligned-vec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "miniz_oxide",
  "num-bigint",
  "quad-rand",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex-lite",
  "serde",
  "serde_bytes",
@@ -578,9 +578,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -705,9 +705,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1263,7 +1263,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "sqlparser",
  "tempfile",
@@ -1535,8 +1535,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.8.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
+version = "0.8.2"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=97375ac981bd075d77f7b1da3d04364894283be4#97375ac981bd075d77f7b1da3d04364894283be4"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1549,8 +1549,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-ranges"
-version = "0.8.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
+version = "0.8.2"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=97375ac981bd075d77f7b1da3d04364894283be4#97375ac981bd075d77f7b1da3d04364894283be4"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1679,7 +1679,7 @@ dependencies = [
  "log",
  "object_store",
  "parquet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -1792,7 +1792,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -1817,7 +1817,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
@@ -1901,7 +1901,7 @@ dependencies = [
  "itertools",
  "log",
  "md-5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -2850,16 +2850,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3112,9 +3111,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3129,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -3209,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3310,15 +3309,15 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdeflate-sys"
@@ -3356,12 +3355,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -3472,9 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3520,7 +3518,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_distr",
  "simba",
  "typenum",
@@ -4078,7 +4076,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4170,7 +4168,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "ring",
  "rustls-pemfile",
@@ -4572,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
@@ -4603,7 +4601,7 @@ dependencies = [
  "log",
  "pyo3",
  "pyo3-log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "tokio",
  "tracing",
@@ -4617,9 +4615,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4732,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -4882,7 +4880,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4940,9 +4938,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4951,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5004,7 +5002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5355,9 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -5428,9 +5426,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5783,15 +5781,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5803,7 +5801,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5857,8 +5855,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superintervals"
-version = "0.10.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6ef78495c01ac049f72d9dceccd5743889818289#6ef78495c01ac049f72d9dceccd5743889818289"
+version = "0.10.2"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=97375ac981bd075d77f7b1da3d04364894283be4#97375ac981bd075d77f7b1da3d04364894283be4"
 dependencies = [
  "aligned-vec",
  "serde",
@@ -6063,9 +6061,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -6262,15 +6260,15 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typewit"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19094686c694eb41b3b99dcc2f2975d4b078512fa22ae6c63f7ca318bdcff7"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unicode-ident"
@@ -6346,9 +6344,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6404,11 +6402,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6417,14 +6415,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6435,9 +6433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6445,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -6455,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2 1.0.106",
@@ -6468,9 +6466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6537,9 +6535,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6557,9 +6555,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6678,15 +6676,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6903,6 +6892,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "7ce101796caade8fef93433b5cf378845d5e9f81" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "7ce101796caade8fef93433b5cf378845d5e9f81", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "6ef78495c01ac049f72d9dceccd5743889818289" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "6ef78495c01ac049f72d9dceccd5743889818289", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "62d1c458b097a32c23b9b506dad1ec1791165d47" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "62d1c458b097a32c23b9b506dad1ec1791165d47", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c248b0317b5e3254b09a015008ff8e05e9f1b065" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c248b0317b5e3254b09a015008ff8e05e9f1b065", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "7ce101796caade8fef93433b5cf378845d5e9f81" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "7ce101796caade8fef93433b5cf378845d5e9f81", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f6444d648d7a0eb9008b6f2530d4e6633e5e7296" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f6444d648d7a0eb9008b6f2530d4e6633e5e7296", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f679a62311ecffff3fba6086dc7bd6280300a958" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f679a62311ecffff3fba6086dc7bd6280300a958", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "6ef78495c01ac049f72d9dceccd5743889818289" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "6ef78495c01ac049f72d9dceccd5743889818289", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "62d1c458b097a32c23b9b506dad1ec1791165d47" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "62d1c458b097a32c23b9b506dad1ec1791165d47", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusio
 datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "19bb44f776eee83dfd7749fe7ed4d82f3ec1a493" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f679a62311ecffff3fba6086dc7bd6280300a958" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f679a62311ecffff3fba6086dc7bd6280300a958", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c248b0317b5e3254b09a015008ff8e05e9f1b065" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c248b0317b5e3254b09a015008ff8e05e9f1b065", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/polars_bio/range_op_helpers.py
+++ b/polars_bio/range_op_helpers.py
@@ -162,12 +162,7 @@ def _lazyframe_to_dataframe(
     This is more efficient than writing to parquet now that GIL is released
     during Arrow operations via py.allow_threads().
     """
-    if hasattr(df, "_base_lf"):
-        # GffLazyFrameWrapper or similar - collect the underlying LazyFrame
-        return df.collect()
-    else:
-        # Regular LazyFrame
-        return df.collect()
+    return df.collect()
 
 
 def range_operation(

--- a/polars_bio/range_op_helpers.py
+++ b/polars_bio/range_op_helpers.py
@@ -15,7 +15,7 @@ from polars_bio.polars_bio import (
 
 from ._metadata import set_coordinate_system
 from .logging import logger
-from .range_op_io import _df_to_reader, _get_schema, _rename_columns, range_lazy_scan
+from .range_op_io import _df_to_reader, _get_schema, range_lazy_scan
 
 try:
     import pandas as pd
@@ -310,9 +310,8 @@ def range_operation(
         zero_based = _get_zero_based_from_filter_op(range_options.filter_op)
 
         if output_type == "polars.LazyFrame":
-            # Get base schemas from collected DataFrames
-            df1_base_schema = _rename_columns(df1, "").schema
-            df2_base_schema = _rename_columns(df2, "").schema
+            df1_base_schema = _get_schema(df1, ctx, None, read_options1)
+            df2_base_schema = _get_schema(df2, ctx, None, read_options2)
 
             # Generate schema based on operation type
             if range_options.range_op == RangeOp.CountOverlapsNaive:

--- a/polars_bio/range_op_io.py
+++ b/polars_bio/range_op_io.py
@@ -225,21 +225,34 @@ def _prepare_lazy_stream_input(
         contig_col: Name of the contig/chromosome column
         batch_size: Batch size for streaming (synced with datafusion.execution.batch_size)
 
-    Note: The schema is extracted from the actual stream (not from Polars schema)
-    to ensure type compatibility (e.g., Utf8View vs LargeUtf8).
+    Note: For LazyFrames we derive the Arrow schema from `collect_schema().to_arrow()`
+    so we do not have to build and consume a temporary Arrow stream just to inspect it.
     """
     if isinstance(df, str):
-        raise ValueError(
-            "File path inputs must be provided for both arguments to use scan-based streaming."
-        )
+        path = Path(df)
+        suffixes = path.suffixes
+
+        if ".parquet" in suffixes:
+            lazy_df = pl.scan_parquet(df)
+        elif ".csv" in suffixes:
+            lazy_df = pl.scan_csv(df)
+        else:
+            raise ValueError(
+                "Mixed LazyFrame + path streaming is only supported for CSV and Parquet inputs."
+            )
+
+        arrow_schema = lazy_df.collect_schema().to_arrow()
+
+        def stream_factory():
+            batches = lazy_df.collect_batches(
+                lazy=True, engine="streaming", chunk_size=batch_size
+            )
+            return batches._inner
+
+        return arrow_schema, stream_factory
 
     if isinstance(df, pl.LazyFrame) or _is_lazyframe_like(df):
-        # Get schema from a temporary stream to ensure type compatibility
-        # (Polars may use Utf8View which differs from LargeUtf8 in empty DataFrame)
-        temp_batches = df.collect_batches(
-            lazy=True, engine="streaming", chunk_size=batch_size
-        )
-        arrow_schema = pa.RecordBatchReader.from_stream(temp_batches._inner).schema
+        arrow_schema = df.collect_schema().to_arrow()
 
         # Return a factory that creates a fresh stream each time
         # This allows the LazyFrame result to be collected multiple times
@@ -318,11 +331,34 @@ def _rename_columns(
 
 
 def _get_schema(
-    path: str,
+    path: Union[str, pl.DataFrame, pl.LazyFrame, "pd.DataFrame"],
     ctx: BioSessionContext,
     suffix=None,
     read_options: Union[ReadOptions, None] = None,
 ) -> pl.Schema:
+    if isinstance(path, pl.LazyFrame):
+        schema = path.collect_schema()
+        return (
+            _rename_columns(pl.DataFrame(schema=schema), suffix).schema
+            if suffix is not None
+            else schema
+        )
+    if isinstance(path, pl.DataFrame):
+        schema = path.schema
+        return (
+            _rename_columns(pl.DataFrame(schema=schema), suffix).schema
+            if suffix is not None
+            else schema
+        )
+    if pd is not None and isinstance(path, pd.DataFrame):
+        polars_df = pl.from_pandas(path)
+        schema = polars_df.schema
+        return (
+            _rename_columns(pl.DataFrame(schema=schema), suffix).schema
+            if suffix is not None
+            else schema
+        )
+
     ext = Path(path).suffixes
     if len(ext) == 0:
         df: DataFrame = py_read_table(ctx, path)

--- a/polars_bio/range_op_io.py
+++ b/polars_bio/range_op_io.py
@@ -336,7 +336,7 @@ def _get_schema(
     suffix=None,
     read_options: Union[ReadOptions, None] = None,
 ) -> pl.Schema:
-    if isinstance(path, pl.LazyFrame):
+    if _is_lazyframe_like(path):
         schema = path.collect_schema()
         return (
             _rename_columns(pl.DataFrame(schema=schema), suffix).schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use datafusion::arrow::ffi_stream::ArrowArrayStreamReader;
 use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::dataframe::DataFrame;
 use datafusion::datasource::MemTable;
+use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
 use datafusion_bio_format_vcf::storage::VcfReader;
 use datafusion_python::dataframe::PyDataFrame;
@@ -260,6 +261,51 @@ fn py_register_table(
                 )))
             },
         }
+    })
+}
+
+/// Test helper: register one Arrow C stream input and return the physical partition count.
+///
+/// This exercises the same streaming-table registration path used by LazyFrame-backed
+/// range operations, but keeps the surface area small for Python unit tests.
+#[pyfunction]
+#[pyo3(signature = (py_ctx, stream, schema))]
+fn py_debug_arrow_stream_partition_count(
+    py: Python<'_>,
+    py_ctx: &PyBioSessionContext,
+    stream: PyArrowType<ArrowArrayStreamReader>,
+    schema: PyArrowType<arrow::datatypes::Schema>,
+) -> PyResult<usize> {
+    let stream_reader = stream.0;
+    let schema = Arc::new(schema.0);
+    let table_name = format!("_debug_stream_{}", rand::random::<u32>());
+
+    py.allow_threads(|| {
+        let rt = Runtime::new().map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let ctx = &py_ctx.ctx;
+
+        register_frame_from_arrow_stream(py_ctx, stream_reader, schema, table_name.clone());
+
+        let partition_count = rt
+            .block_on(async {
+                let df = ctx
+                    .table(&table_name)
+                    .await
+                    .map_err(|e| format!("Failed to access debug table: {}", e))?;
+                let logical_plan = df.logical_plan().clone();
+                let physical_plan = ctx
+                    .state()
+                    .create_physical_plan(&logical_plan)
+                    .await
+                    .map_err(|e| format!("Failed to build debug physical plan: {}", e))?;
+                Ok::<usize, String>(physical_plan.output_partitioning().partition_count())
+            })
+            .map_err(PyRuntimeError::new_err)?;
+
+        ctx.deregister_table(&table_name)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+        Ok(partition_count)
     })
 }
 
@@ -736,6 +782,7 @@ fn polars_bio(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(range_operation_lazy, m)?)?;
     m.add_function(wrap_pyfunction!(range_operation_scan, m)?)?;
     m.add_function(wrap_pyfunction!(py_register_table, m)?)?;
+    m.add_function(wrap_pyfunction!(py_debug_arrow_stream_partition_count, m)?)?;
     m.add_function(wrap_pyfunction!(py_read_table, m)?)?;
     m.add_function(wrap_pyfunction!(py_read_sql, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_table_schema, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use crate::option::{
 };
 use crate::scan::{
     maybe_register_table, register_frame, register_frame_from_arrow_stream,
-    register_frame_from_batches, register_table,
+    register_frame_from_arrow_stream_single_partition, register_frame_from_batches, register_table,
 };
 
 const LEFT_TABLE: &str = "s1";
@@ -617,7 +617,12 @@ fn py_write_table(
         // Register a streaming table backed directly by the Arrow C Stream.
         // This avoids materializing all batches in Python and lets DataFusion
         // pull data on demand without the GIL.
-        register_frame_from_arrow_stream(
+        //
+        // Writes intentionally keep Arrow-stream inputs single-partition even when
+        // the session target_partitions is > 1. The downstream write path coalesces
+        // to one partition to emit a single file, but that coalescing does not
+        // preserve row order across parallel input partitions.
+        register_frame_from_arrow_stream_single_partition(
             py_ctx,
             stream_reader,
             schema.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ fn py_register_table(
 ///
 /// This exercises the same streaming-table registration path used by LazyFrame-backed
 /// range operations, but keeps the surface area small for Python unit tests.
-#[pyfunction]
+#[pyfunction(name = "_debug_arrow_stream_partition_count")]
 #[pyo3(signature = (py_ctx, stream, schema))]
 fn py_debug_arrow_stream_partition_count(
     py: Python<'_>,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -135,6 +135,10 @@ impl Stream for ArrowCStreamBatchStream {
     type Item = Result<RecordBatch, DataFusionError>;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // For single-partition execution we keep the implementation simple and read
+        // directly from the Arrow C stream on the consumer task. The multi-partition
+        // path uses a dedicated OS thread plus bounded channels so probe-side
+        // parallelism does not depend on synchronous reads inside `poll_next`.
         match self.reader.next() {
             Some(Ok(batch)) => Poll::Ready(Some(Ok(batch))),
             Some(Err(e)) => Poll::Ready(Some(Err(DataFusionError::External(Box::new(e))))),
@@ -282,6 +286,11 @@ fn create_arrow_stream_partition_streams(
         )) as Arc<dyn PartitionStream>);
     }
 
+    // The bounded fanout queues rely on downstream consumers polling partitions
+    // concurrently. That is true for the current DataFusion `execute_stream()`
+    // path, which coalesces multi-partition plans by spawning one task per input
+    // partition. If a future caller were to drain these partitions strictly
+    // sequentially, this fanout design would need to be revisited.
     thread::Builder::new()
         .name("arrow-c-stream-fanout".to_string())
         .spawn(move || dispatch_arrow_stream_batches(stream_reader, senders))

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -299,6 +299,23 @@ fn create_arrow_stream_partition_streams(
     partitions
 }
 
+fn register_frame_from_arrow_stream_with_partitions(
+    py_ctx: &PyBioSessionContext,
+    stream_reader: ArrowArrayStreamReader,
+    schema: Arc<arrow::datatypes::Schema>,
+    table_name: String,
+    target_partitions: usize,
+) {
+    let ctx = &py_ctx.ctx;
+    let partitions =
+        create_arrow_stream_partition_streams(schema.clone(), stream_reader, target_partitions);
+    let table_source = StreamingTable::try_new(schema, partitions).unwrap();
+
+    ctx.deregister_table(&table_name).unwrap();
+    ctx.register_table(&table_name, Arc::new(table_source))
+        .unwrap();
+}
+
 pub(crate) fn register_frame(
     py_ctx: &PyBioSessionContext,
     df: PyArrowType<ArrowArrayStreamReader>,
@@ -354,15 +371,33 @@ pub(crate) fn register_frame_from_arrow_stream(
     schema: Arc<arrow::datatypes::Schema>,
     table_name: String,
 ) {
-    let ctx = &py_ctx.ctx;
-    let target_partitions = ctx.state().config().options().execution.target_partitions;
-    let partitions =
-        create_arrow_stream_partition_streams(schema.clone(), stream_reader, target_partitions);
-    let table_source = StreamingTable::try_new(schema, partitions).unwrap();
+    let target_partitions = py_ctx
+        .ctx
+        .state()
+        .config()
+        .options()
+        .execution
+        .target_partitions;
+    register_frame_from_arrow_stream_with_partitions(
+        py_ctx,
+        stream_reader,
+        schema,
+        table_name,
+        target_partitions,
+    );
+}
 
-    ctx.deregister_table(&table_name).unwrap();
-    ctx.register_table(&table_name, Arc::new(table_source))
-        .unwrap();
+/// Register an Arrow C stream as a single-partition streaming table.
+///
+/// Writers use this path so their input row order does not depend on session-level
+/// partition fanout. Range operations should continue to use the partition-aware path.
+pub(crate) fn register_frame_from_arrow_stream_single_partition(
+    py_ctx: &PyBioSessionContext,
+    stream_reader: ArrowArrayStreamReader,
+    schema: Arc<arrow::datatypes::Schema>,
+    table_name: String,
+) {
+    register_frame_from_arrow_stream_with_partitions(py_ctx, stream_reader, schema, table_name, 1);
 }
 
 pub(crate) fn get_input_format(path: &str) -> InputFormat {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -234,7 +234,7 @@ fn dispatch_arrow_stream_batches(
     mut stream_reader: ArrowArrayStreamReader,
     senders: Vec<Sender<Result<RecordBatch, DataFusionError>>>,
 ) {
-    let partition_count = senders.len().max(1);
+    let partition_count = senders.len();
 
     for (batch_index, batch_result) in stream_reader.by_ref().enumerate() {
         match batch_result {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::thread;
 
 use arrow::array::{RecordBatch, RecordBatchReader};
 use arrow::error::ArrowError;
@@ -25,6 +26,7 @@ use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use futures::Stream;
 use log::info;
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tracing::debug;
 
 use crate::context::PyBioSessionContext;
@@ -32,6 +34,13 @@ use crate::option::{
     BamReadOptions, BedReadOptions, CramReadOptions, FastaReadOptions, FastqReadOptions,
     GffReadOptions, GtfReadOptions, InputFormat, PairsReadOptions, ReadOptions, VcfReadOptions,
 };
+
+/// Maximum number of RecordBatches buffered per partition when fanning out a LazyFrame
+/// Arrow C stream into multiple DataFusion partitions.
+///
+/// Keeping this small preserves streaming behavior and provides backpressure to the
+/// dispatcher thread instead of allowing it to accumulate the full input in memory.
+const ARROW_STREAM_PARTITION_BUFFER_SIZE: usize = 2;
 
 /// A PartitionStream that yields pre-collected RecordBatches.
 /// Used to enable multi-partition parallel execution for DataFrame inputs.
@@ -140,6 +149,56 @@ impl RecordBatchStream for ArrowCStreamBatchStream {
     }
 }
 
+/// A PartitionStream backed by a receiver fed from a shared Arrow C stream.
+///
+/// The source stream is read once and batches are dispatched round-robin to each
+/// partition receiver so DataFusion can execute probe-side partitions in parallel.
+pub struct ArrowCStreamFanoutPartitionStream {
+    schema: SchemaRef,
+    receiver: Arc<Mutex<Option<Receiver<Result<RecordBatch, DataFusionError>>>>>,
+}
+
+impl ArrowCStreamFanoutPartitionStream {
+    pub fn new(
+        schema: SchemaRef,
+        receiver: Receiver<Result<RecordBatch, DataFusionError>>,
+    ) -> Self {
+        Self {
+            schema,
+            receiver: Arc::new(Mutex::new(Some(receiver))),
+        }
+    }
+}
+
+impl std::fmt::Debug for ArrowCStreamFanoutPartitionStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArrowCStreamFanoutPartitionStream")
+            .field("schema", &self.schema)
+            .finish()
+    }
+}
+
+impl PartitionStream for ArrowCStreamFanoutPartitionStream {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let receiver = self
+            .receiver
+            .lock()
+            .unwrap()
+            .take()
+            .expect("Arrow C Stream partition already consumed");
+
+        let stream = futures::stream::unfold(receiver, |mut receiver| async move {
+            receiver.recv().await.map(|batch| (batch, receiver))
+        });
+
+        Box::pin(RecordBatchStreamAdapter::new(self.schema.clone(), stream))
+    }
+}
+
 /// Distributes RecordBatches into PartitionStreams for parallel execution.
 /// Uses round-robin distribution to balance batches across partitions.
 fn create_partition_streams(
@@ -169,6 +228,66 @@ fn create_partition_streams(
                 as Arc<dyn PartitionStream>
         })
         .collect()
+}
+
+fn dispatch_arrow_stream_batches(
+    mut stream_reader: ArrowArrayStreamReader,
+    senders: Vec<Sender<Result<RecordBatch, DataFusionError>>>,
+) {
+    let partition_count = senders.len().max(1);
+
+    for (batch_index, batch_result) in stream_reader.by_ref().enumerate() {
+        match batch_result {
+            Ok(batch) => {
+                let partition_idx = batch_index % partition_count;
+                if senders[partition_idx].blocking_send(Ok(batch)).is_err() {
+                    // The query stopped consuming this stream, so stop dispatching.
+                    return;
+                }
+            },
+            Err(error) => {
+                let message = format!("Arrow C Stream read failed: {}", error);
+                for sender in &senders {
+                    let _ = sender.blocking_send(Err(DataFusionError::Execution(message.clone())));
+                }
+                return;
+            },
+        }
+    }
+}
+
+fn create_arrow_stream_partition_streams(
+    schema: SchemaRef,
+    stream_reader: ArrowArrayStreamReader,
+    target_partitions: usize,
+) -> Vec<Arc<dyn PartitionStream>> {
+    let num_partitions = target_partitions.max(1);
+
+    if num_partitions == 1 {
+        return vec![
+            Arc::new(ArrowCStreamPartitionStream::new(schema, stream_reader))
+                as Arc<dyn PartitionStream>,
+        ];
+    }
+
+    let mut senders = Vec::with_capacity(num_partitions);
+    let mut partitions = Vec::with_capacity(num_partitions);
+
+    for _ in 0..num_partitions {
+        let (sender, receiver) = channel(ARROW_STREAM_PARTITION_BUFFER_SIZE);
+        senders.push(sender);
+        partitions.push(Arc::new(ArrowCStreamFanoutPartitionStream::new(
+            schema.clone(),
+            receiver,
+        )) as Arc<dyn PartitionStream>);
+    }
+
+    thread::Builder::new()
+        .name("arrow-c-stream-fanout".to_string())
+        .spawn(move || dispatch_arrow_stream_batches(stream_reader, senders))
+        .expect("failed to spawn Arrow C Stream fanout thread");
+
+    partitions
 }
 
 pub(crate) fn register_frame(
@@ -227,15 +346,10 @@ pub(crate) fn register_frame_from_arrow_stream(
     table_name: String,
 ) {
     let ctx = &py_ctx.ctx;
-
-    // Create a single partition stream that reads from Arrow C Stream
-    let partition = Arc::new(ArrowCStreamPartitionStream::new(
-        schema.clone(),
-        stream_reader,
-    )) as Arc<dyn PartitionStream>;
-
-    // Use StreamingTable with the Arrow C Stream partition
-    let table_source = StreamingTable::try_new(schema, vec![partition]).unwrap();
+    let target_partitions = ctx.state().config().options().execution.target_partitions;
+    let partitions =
+        create_arrow_stream_partition_streams(schema.clone(), stream_reader, target_partitions);
+    let table_source = StreamingTable::try_new(schema, partitions).unwrap();
 
     ctx.deregister_table(&table_name).unwrap();
     ctx.register_table(&table_name, Arc::new(table_source))

--- a/tests/test_bioframe.py
+++ b/tests/test_bioframe.py
@@ -1,15 +1,36 @@
+from contextlib import contextmanager
+
 import bioframe as bf
 import pandas as pd
+import polars as pl
+import pytest
 from _expected import BIO_DF_PATH1, BIO_DF_PATH2, BIO_PD_DF1, BIO_PD_DF2
 from numpy import int32
 
 import polars_bio as pb
 
 pb.ctx.set_option("datafusion.execution.parquet.schema_force_view_types", "true", False)
+TARGET_PARTITIONS_KEY = "datafusion.execution.target_partitions"
 
 # Set coordinate system metadata on pandas DataFrames (0-based for bioframe compatibility)
 BIO_PD_DF1.attrs["coordinate_system_zero_based"] = True
 BIO_PD_DF2.attrs["coordinate_system_zero_based"] = True
+
+
+@contextmanager
+def _target_partitions(partitions: int):
+    original = pb.get_option(TARGET_PARTITIONS_KEY)
+    pb.set_option(TARGET_PARTITIONS_KEY, str(partitions))
+    try:
+        yield
+    finally:
+        pb.set_option(TARGET_PARTITIONS_KEY, original if original is not None else "1")
+
+
+def _scan_parquet_with_metadata(path: str) -> pl.LazyFrame:
+    lf = pl.scan_parquet(path)
+    lf.config_meta.set(coordinate_system_zero_based=True)
+    return lf
 
 
 class TestBioframe:
@@ -68,8 +89,6 @@ class TestBioframe:
     )
 
     # For file paths, we need to use polars scan with metadata set.
-    import polars as pl
-
     _df1_parquet = pl.scan_parquet(BIO_DF_PATH1)
     _df1_parquet.config_meta.set(coordinate_system_zero_based=True)
     _df2_parquet = pl.scan_parquet(BIO_DF_PATH2)
@@ -123,6 +142,29 @@ class TestBioframe:
         pd.testing.assert_frame_equal(result, expected)
         pd.testing.assert_frame_equal(result_lf, expected)
 
+    def test_overlap_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.overlap(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    _scan_parquet_with_metadata(BIO_DF_PATH2),
+                    cols1=("contig", "pos_start", "pos_end"),
+                    cols2=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                    suffixes=("_1", "_3"),
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = self.result_bio_overlap.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        result_parallel = result_parallel.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)
+
     def test_nearest_count(self):
         assert len(self.result_nearest) == len(self.result_bio_nearest)
 
@@ -142,6 +184,34 @@ class TestBioframe:
         ).reset_index(drop=True)
         result = result.drop(columns=["pos_start_2", "pos_end_2"])
         pd.testing.assert_frame_equal(result, expected)
+
+    def test_nearest_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.nearest(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    _scan_parquet_with_metadata(BIO_DF_PATH2),
+                    cols1=("contig", "pos_start", "pos_end"),
+                    cols2=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = (
+            self.result_bio_nearest.sort_values(
+                by=list(["contig_1", "pos_start_1", "pos_end_1", "distance"])
+            )
+            .reset_index(drop=True)
+            .astype({"pos_start_2": int32, "pos_end_2": int32, "distance": int})
+        )
+        expected = expected.drop(columns=["pos_start_2", "pos_end_2"])
+        result_parallel = result_parallel.sort_values(
+            by=list(["contig_1", "pos_start_1", "pos_end_1", "distance"])
+        ).reset_index(drop=True)
+        result_parallel = result_parallel.drop(columns=["pos_start_2", "pos_end_2"])
+        pd.testing.assert_frame_equal(result_parallel, expected)
 
     def test_overlaps_count(self):
         assert len(self.result_count_overlaps) == len(self.result_bio_count_overlaps)
@@ -171,6 +241,31 @@ class TestBioframe:
         pd.testing.assert_frame_equal(result, expected)
         pd.testing.assert_frame_equal(result_naive, expected, check_dtype=True)
 
+    def test_overlaps_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.count_overlaps(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    _scan_parquet_with_metadata(BIO_DF_PATH2),
+                    cols1=("contig", "pos_start", "pos_end"),
+                    cols2=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                    naive_query=False,
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = (
+            self.result_bio_count_overlaps.sort_values(by=list(result_parallel.columns))
+            .reset_index(drop=True)
+            .astype({"count": int})
+        )
+        result_parallel = result_parallel.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)
+
     def test_merge_count(self):
         assert len(self.result_merge) == len(self.result_bio_merge)
         assert len(self.result_merge_lf.collect()) == len(self.result_bio_merge)
@@ -183,6 +278,26 @@ class TestBioframe:
             by=list(self.result_merge.columns)
         ).reset_index(drop=True)
         pd.testing.assert_frame_equal(result, expected)
+
+    def test_merge_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.merge(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    cols=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = self.result_bio_merge.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        result_parallel = result_parallel.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)
 
     def test_coverage_count(self):
         result = pb.coverage(
@@ -224,6 +339,37 @@ class TestBioframe:
         result = result.sort_values(by=list(result.columns)).reset_index(drop=True)
         pd.testing.assert_frame_equal(result, expected)
 
+    def test_coverage_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.coverage(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    _scan_parquet_with_metadata(BIO_DF_PATH2),
+                    cols1=("contig", "pos_start", "pos_end"),
+                    cols2=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = (
+            bf.coverage(
+                BIO_PD_DF1,
+                BIO_PD_DF2,
+                cols1=("contig", "pos_start", "pos_end"),
+                cols2=("contig", "pos_start", "pos_end"),
+                suffixes=("_1", "_2"),
+            )
+            .sort_values(by=list(result_parallel.columns))
+            .reset_index(drop=True)
+            .astype({"coverage": "int64"})
+        )
+        result_parallel = result_parallel.sort_values(
+            by=list(result_parallel.columns)
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)
+
     # ------------------------------------------------------------------ cluster
     result_cluster = pb.cluster(
         BIO_PD_DF1,
@@ -264,6 +410,51 @@ class TestBioframe:
         )
         pd.testing.assert_frame_equal(result, expected)
 
+    @pytest.mark.xfail(
+        reason="cluster boundaries still diverge from bioframe under target_partitions=4"
+    )
+    def test_cluster_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.cluster(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    cols=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        # Cluster ids are labels rather than part of the interval semantics and can
+        # be renumbered under partitioned execution. Compare the interval boundaries
+        # and the derived cluster extents instead.
+        sort_columns = [
+            "contig",
+            "pos_start",
+            "pos_end",
+            "cluster_start",
+            "cluster_end",
+        ]
+        result_parallel = (
+            result_parallel.drop(columns=["cluster"])
+            .sort_values(by=sort_columns)
+            .reset_index(drop=True)
+        )
+        expected = (
+            self.result_bio_cluster.drop(columns=["cluster"])
+            .sort_values(by=sort_columns)
+            .reset_index(drop=True)
+            .astype(
+                {
+                    "pos_start": "int64",
+                    "pos_end": "int64",
+                    "cluster_start": "int64",
+                    "cluster_end": "int64",
+                }
+            )
+        )
+        pd.testing.assert_frame_equal(result_parallel, expected)
+
     # --------------------------------------------------------------- complement
     # Build a view_df with contig boundaries (min start, max end per contig)
     _view_df = (
@@ -303,6 +494,28 @@ class TestBioframe:
         ).reset_index(drop=True)
         pd.testing.assert_frame_equal(result, expected)
 
+    def test_complement_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.complement(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    view_df=self._view_df,
+                    cols=("contig", "pos_start", "pos_end"),
+                    view_cols=("chrom", "start", "end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = self.result_bio_complement.sort_values(
+            by=["contig", "pos_start", "pos_end"]
+        ).reset_index(drop=True)
+        result_parallel = result_parallel.sort_values(
+            by=["contig", "pos_start", "pos_end"]
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)
+
     # ---------------------------------------------------------------- subtract
     result_subtract = pb.subtract(
         BIO_PD_DF1,
@@ -329,3 +542,25 @@ class TestBioframe:
             by=["contig", "pos_start", "pos_end"]
         ).reset_index(drop=True)
         pd.testing.assert_frame_equal(result, expected)
+
+    def test_subtract_parallel_lazyframe_schema_rows(self):
+        with _target_partitions(4):
+            result_parallel = (
+                pb.subtract(
+                    _scan_parquet_with_metadata(BIO_DF_PATH1),
+                    _scan_parquet_with_metadata(BIO_DF_PATH2),
+                    cols1=("contig", "pos_start", "pos_end"),
+                    cols2=("contig", "pos_start", "pos_end"),
+                    output_type="polars.LazyFrame",
+                )
+                .collect(engine="streaming")
+                .to_pandas()
+            )
+
+        expected = self.result_bio_subtract.sort_values(
+            by=["contig", "pos_start", "pos_end"]
+        ).reset_index(drop=True)
+        result_parallel = result_parallel.sort_values(
+            by=["contig", "pos_start", "pos_end"]
+        ).reset_index(drop=True)
+        pd.testing.assert_frame_equal(result_parallel, expected)

--- a/tests/test_bioframe.py
+++ b/tests/test_bioframe.py
@@ -410,9 +410,6 @@ class TestBioframe:
         )
         pd.testing.assert_frame_equal(result, expected)
 
-    @pytest.mark.xfail(
-        reason="cluster boundaries still diverge from bioframe under target_partitions=4"
-    )
     def test_cluster_parallel_lazyframe_schema_rows(self):
         with _target_partitions(4):
             result_parallel = (

--- a/tests/test_io_fastq.py
+++ b/tests/test_io_fastq.py
@@ -3,6 +3,17 @@ from _expected import DATA_DIR
 
 import polars_bio as pb
 
+TARGET_PARTITIONS_KEY = "datafusion.execution.target_partitions"
+
+
+@pytest.fixture(autouse=True)
+def _restore_target_partitions():
+    original_target_partitions = pb.get_option(TARGET_PARTITIONS_KEY)
+    try:
+        yield
+    finally:
+        pb.set_option(TARGET_PARTITIONS_KEY, original_target_partitions)
+
 
 class TestFastq:
     def test_count(self):
@@ -51,7 +62,7 @@ class TestFastq:
 class TestParallelFastq:
     @pytest.mark.parametrize("partitions", [1, 2, 3, 4])
     def test_read_parallel_fastq(self, partitions):
-        pb.set_option("datafusion.execution.target_partitions", str(partitions))
+        pb.set_option(TARGET_PARTITIONS_KEY, str(partitions))
         df = pb.read_fastq(
             f"{DATA_DIR}/io/fastq/sample_parallel.fastq.bgz",
         )

--- a/tests/test_lazyframe_partitioning.py
+++ b/tests/test_lazyframe_partitioning.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import contextmanager
+
+import polars as pl
+import pytest
+from _expected import (
+    DF_COUNT_OVERLAPS_PATH1,
+    DF_COUNT_OVERLAPS_PATH2,
+    DF_COVERAGE_PATH1,
+    DF_COVERAGE_PATH2,
+    DF_MERGE_PATH,
+    DF_NEAREST_PATH1,
+    DF_NEAREST_PATH2,
+    DF_OVER_PATH1,
+    DF_OVER_PATH2,
+)
+
+import polars_bio as pb
+from polars_bio.polars_bio import py_debug_arrow_stream_partition_count
+from polars_bio.range_op_io import _prepare_lazy_stream_input
+
+COLUMNS = ["contig", "pos_start", "pos_end"]
+TARGET_PARTITIONS_KEY = "datafusion.execution.target_partitions"
+BATCH_SIZE_KEY = "datafusion.execution.batch_size"
+
+
+def _read_csv_with_metadata(path: str, zero_based: bool) -> pl.DataFrame:
+    df = pl.read_csv(path)
+    df.config_meta.set(coordinate_system_zero_based=zero_based)
+    return df
+
+
+def _scan_csv_with_metadata(path: str, zero_based: bool) -> pl.LazyFrame:
+    lf = pl.scan_csv(path)
+    lf.config_meta.set(coordinate_system_zero_based=zero_based)
+    return lf
+
+
+@contextmanager
+def _target_partitions(partitions: int):
+    with _session_option(TARGET_PARTITIONS_KEY, str(partitions)):
+        yield
+
+
+@contextmanager
+def _session_option(key: str, value: str):
+    original = pb.get_option(key)
+    pb.set_option(key, value)
+    try:
+        yield
+    finally:
+        pb.set_option(key, original or "1")
+
+
+def _sorted(df: pl.DataFrame) -> pl.DataFrame:
+    if not df.columns:
+        return df
+    return df.sort(df.columns)
+
+
+def _assert_same_rows(expected: pl.DataFrame, actual: pl.DataFrame) -> None:
+    pl.testing.assert_frame_equal(_sorted(expected), _sorted(actual))
+
+
+def _build_overlap_case():
+    df1 = _read_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+    expected = pb.overlap(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.overlap(
+            _scan_csv_with_metadata(DF_OVER_PATH1, zero_based=False),
+            _scan_csv_with_metadata(DF_OVER_PATH2, zero_based=False),
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_mixed_lazy_dataframe_overlap_case(left_lazy: bool):
+    df1 = _read_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+    expected = pb.overlap(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        left = (
+            _scan_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+            if left_lazy
+            else df1
+        )
+        right = (
+            df2
+            if left_lazy
+            else _scan_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+        )
+        return pb.overlap(
+            left,
+            right,
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_mixed_lazy_path_overlap_case(left_lazy: bool):
+    df1 = _read_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+    expected = pb.overlap(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        left = (
+            _scan_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+            if left_lazy
+            else DF_OVER_PATH1
+        )
+        right = (
+            DF_OVER_PATH2
+            if left_lazy
+            else _scan_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+        )
+        return pb.overlap(
+            left,
+            right,
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_nearest_case():
+    df1 = _read_csv_with_metadata(DF_NEAREST_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_NEAREST_PATH2, zero_based=False)
+    expected = pb.nearest(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.nearest(
+            _scan_csv_with_metadata(DF_NEAREST_PATH1, zero_based=False),
+            _scan_csv_with_metadata(DF_NEAREST_PATH2, zero_based=False),
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_count_overlaps_case():
+    df1 = _read_csv_with_metadata(DF_COUNT_OVERLAPS_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_COUNT_OVERLAPS_PATH2, zero_based=False)
+    expected = pb.count_overlaps(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.count_overlaps(
+            _scan_csv_with_metadata(DF_COUNT_OVERLAPS_PATH1, zero_based=False),
+            _scan_csv_with_metadata(DF_COUNT_OVERLAPS_PATH2, zero_based=False),
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_coverage_case():
+    df1 = _read_csv_with_metadata(DF_COVERAGE_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_COVERAGE_PATH2, zero_based=False)
+    expected = pb.coverage(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.coverage(
+            _scan_csv_with_metadata(DF_COVERAGE_PATH1, zero_based=False),
+            _scan_csv_with_metadata(DF_COVERAGE_PATH2, zero_based=False),
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_merge_case():
+    df = _read_csv_with_metadata(DF_MERGE_PATH, zero_based=True)
+    expected = pb.merge(
+        df,
+        cols=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.merge(
+            _scan_csv_with_metadata(DF_MERGE_PATH, zero_based=True),
+            cols=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_cluster_case():
+    df = _read_csv_with_metadata(DF_MERGE_PATH, zero_based=True)
+    expected = pb.cluster(
+        df,
+        cols=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.cluster(
+            _scan_csv_with_metadata(DF_MERGE_PATH, zero_based=True),
+            cols=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_complement_case():
+    df = _read_csv_with_metadata(DF_MERGE_PATH, zero_based=True)
+    view_df = (
+        df.group_by("contig")
+        .agg(
+            pl.col("pos_start").min().alias("start"),
+            pl.col("pos_end").max().alias("end"),
+        )
+        .rename({"contig": "chrom"})
+    )
+    view_df.config_meta.set(coordinate_system_zero_based=True)
+
+    expected = pb.complement(
+        df,
+        view_df=view_df,
+        cols=COLUMNS,
+        view_cols=["chrom", "start", "end"],
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.complement(
+            _scan_csv_with_metadata(DF_MERGE_PATH, zero_based=True),
+            view_df=view_df,
+            cols=COLUMNS,
+            view_cols=["chrom", "start", "end"],
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _build_subtract_case():
+    df1 = _read_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+    df2 = _read_csv_with_metadata(DF_OVER_PATH2, zero_based=False)
+    expected = pb.subtract(
+        df1,
+        df2,
+        cols1=COLUMNS,
+        cols2=COLUMNS,
+        output_type="polars.DataFrame",
+    )
+
+    def factory() -> pl.LazyFrame:
+        return pb.subtract(
+            _scan_csv_with_metadata(DF_OVER_PATH1, zero_based=False),
+            _scan_csv_with_metadata(DF_OVER_PATH2, zero_based=False),
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        )
+
+    return expected, factory
+
+
+def _lazy_input_partition_count(path: str, zero_based: bool) -> int:
+    lazyframe = _scan_csv_with_metadata(path, zero_based=zero_based)
+    schema, stream_factory = _prepare_lazy_stream_input(
+        lazyframe, COLUMNS[0], batch_size=2
+    )
+    return py_debug_arrow_stream_partition_count(pb.ctx, stream_factory(), schema)
+
+
+@pytest.mark.parametrize(
+    ("path", "zero_based"),
+    [
+        (DF_OVER_PATH1, False),
+        (DF_MERGE_PATH, True),
+    ],
+    ids=["binary-input", "unary-input"],
+)
+@pytest.mark.parametrize("target_partitions", [1, 4])
+def test_lazy_arrow_stream_partition_count_matches_target_partitions(
+    path: str,
+    zero_based: bool,
+    target_partitions: int,
+):
+    with _target_partitions(target_partitions):
+        partition_count = _lazy_input_partition_count(path, zero_based=zero_based)
+
+    assert partition_count == target_partitions
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        _build_overlap_case,
+        _build_nearest_case,
+        _build_count_overlaps_case,
+        _build_coverage_case,
+        _build_merge_case,
+        _build_cluster_case,
+        _build_complement_case,
+        _build_subtract_case,
+    ],
+    ids=[
+        "overlap",
+        "nearest",
+        "count_overlaps",
+        "coverage",
+        "merge",
+        "cluster",
+        "complement",
+        "subtract",
+    ],
+)
+def test_lazy_range_operations_preserve_results_across_partitions(builder):
+    expected, lazy_factory = builder()
+
+    with _target_partitions(1):
+        result_single = lazy_factory().collect(engine="streaming")
+
+    with _target_partitions(4):
+        result_partitioned = lazy_factory().collect(engine="streaming")
+
+    _assert_same_rows(expected, result_single)
+    _assert_same_rows(expected, result_partitioned)
+    _assert_same_rows(result_single, result_partitioned)
+
+
+@pytest.mark.parametrize(
+    "left_lazy", [True, False], ids=["lazy+dataframe", "dataframe+lazy"]
+)
+def test_partitioned_lazy_stream_supports_mixed_lazy_and_dataframe_inputs(left_lazy):
+    expected, lazy_factory = _build_mixed_lazy_dataframe_overlap_case(left_lazy)
+
+    with _target_partitions(1):
+        result_single = lazy_factory().collect(engine="streaming")
+
+    with _target_partitions(4):
+        result_partitioned = lazy_factory().collect(engine="streaming")
+
+    _assert_same_rows(expected, result_single)
+    _assert_same_rows(expected, result_partitioned)
+    _assert_same_rows(result_single, result_partitioned)
+
+
+@pytest.mark.parametrize("left_lazy", [True, False], ids=["lazy+path", "path+lazy"])
+def test_partitioned_lazy_stream_supports_mixed_lazy_and_path_inputs(left_lazy):
+    expected, lazy_factory = _build_mixed_lazy_path_overlap_case(left_lazy)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Coordinate system metadata is missing.*",
+            category=UserWarning,
+        )
+        with (
+            _session_option("datafusion.bio.coordinate_system_check", "false"),
+            _session_option("datafusion.bio.coordinate_system_zero_based", "false"),
+            _target_partitions(1),
+        ):
+            result_single = lazy_factory().collect(engine="streaming")
+
+        with (
+            _session_option("datafusion.bio.coordinate_system_check", "false"),
+            _session_option("datafusion.bio.coordinate_system_zero_based", "false"),
+            _target_partitions(4),
+        ):
+            result_partitioned = lazy_factory().collect(engine="streaming")
+
+    _assert_same_rows(expected, result_single)
+    _assert_same_rows(expected, result_partitioned)
+    _assert_same_rows(result_single, result_partitioned)
+
+
+@pytest.mark.parametrize(
+    "builder", [_build_overlap_case, _build_merge_case], ids=["overlap", "merge"]
+)
+def test_partitioned_lazy_stream_supports_prefix_consumption(builder):
+    _, lazy_factory = builder()
+
+    with _target_partitions(4), _session_option(BATCH_SIZE_KEY, "1"):
+        result = lazy_factory().head(1).collect(engine="streaming")
+
+    assert len(result) == 1

--- a/tests/test_lazyframe_partitioning.py
+++ b/tests/test_lazyframe_partitioning.py
@@ -18,12 +18,32 @@ from _expected import (
 )
 
 import polars_bio as pb
-from polars_bio.polars_bio import py_debug_arrow_stream_partition_count
-from polars_bio.range_op_io import _prepare_lazy_stream_input
+from polars_bio.polars_bio import _debug_arrow_stream_partition_count
+from polars_bio.range_op_io import _get_schema, _prepare_lazy_stream_input
 
 COLUMNS = ["contig", "pos_start", "pos_end"]
 TARGET_PARTITIONS_KEY = "datafusion.execution.target_partitions"
 BATCH_SIZE_KEY = "datafusion.execution.batch_size"
+OPTION_DEFAULTS = {
+    TARGET_PARTITIONS_KEY: "1",
+    BATCH_SIZE_KEY: "8192",
+    "datafusion.bio.coordinate_system_check": "false",
+    "datafusion.bio.coordinate_system_zero_based": "false",
+}
+
+
+class _DummyLazyWrapper:
+    def __init__(self, base_lf: pl.LazyFrame):
+        self._base_lf = base_lf
+
+    def collect_schema(self):
+        return self._base_lf.collect_schema()
+
+    def collect_batches(self, *args, **kwargs):
+        return self._base_lf.collect_batches(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._base_lf, name)
 
 
 def _read_csv_with_metadata(path: str, zero_based: bool) -> pl.DataFrame:
@@ -51,7 +71,10 @@ def _session_option(key: str, value: str):
     try:
         yield
     finally:
-        pb.set_option(key, original or "1")
+        restored = original if original is not None else OPTION_DEFAULTS.get(key)
+        if restored is None:
+            raise AssertionError(f"No restore value configured for option: {key}")
+        pb.set_option(key, restored)
 
 
 def _sorted(df: pl.DataFrame) -> pl.DataFrame:
@@ -318,7 +341,18 @@ def _lazy_input_partition_count(path: str, zero_based: bool) -> int:
     schema, stream_factory = _prepare_lazy_stream_input(
         lazyframe, COLUMNS[0], batch_size=2
     )
-    return py_debug_arrow_stream_partition_count(pb.ctx, stream_factory(), schema)
+    return _debug_arrow_stream_partition_count(pb.ctx, stream_factory(), schema)
+
+
+def test_get_schema_supports_lazyframe_wrappers():
+    lazyframe = _scan_csv_with_metadata(DF_OVER_PATH1, zero_based=False)
+    wrapper = _DummyLazyWrapper(lazyframe)
+
+    schema = _get_schema(wrapper, pb.ctx)
+    suffixed_schema = _get_schema(wrapper, pb.ctx, "_x")
+
+    assert schema == lazyframe.collect_schema()
+    assert suffixed_schema.names() == [f"{name}_x" for name in schema.names()]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_partitioned_range_operation_regressions.py
+++ b/tests/test_partitioned_range_operation_regressions.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import polars_bio as pb
+
+COLUMNS = ["contig", "pos_start", "pos_end"]
+VIEW_COLUMNS = ["chrom", "start", "end"]
+TARGET_PARTITIONS_KEY = "datafusion.execution.target_partitions"
+BATCH_SIZE_KEY = "datafusion.execution.batch_size"
+OPTION_DEFAULTS = {
+    TARGET_PARTITIONS_KEY: "1",
+    BATCH_SIZE_KEY: "8192",
+    "datafusion.bio.coordinate_system_check": "false",
+    "datafusion.bio.coordinate_system_zero_based": "false",
+}
+
+EXPECTED_MERGE = pl.DataFrame(
+    {
+        "contig": ["chr1"],
+        "pos_start": [0],
+        "pos_end": [30],
+        "n_intervals": [3],
+    }
+)
+
+EXPECTED_COMPLEMENT = pl.DataFrame(
+    {
+        "contig": ["chr1"],
+        "pos_start": [30],
+        "pos_end": [40],
+    }
+)
+
+EXPECTED_SUBTRACT = pl.DataFrame(
+    {
+        "contig": ["chr1", "chr1", "chr1"],
+        "pos_start": [0, 10, 25],
+        "pos_end": [5, 20, 30],
+    }
+)
+
+EXPECTED_CLUSTER = pl.DataFrame(
+    {
+        "contig": ["chr1", "chr1", "chr1"],
+        "pos_start": [0, 8, 20],
+        "pos_end": [10, 25, 30],
+        "cluster": [0, 0, 0],
+        "cluster_start": [0, 0, 0],
+        "cluster_end": [30, 30, 30],
+    }
+)
+
+
+@dataclass(frozen=True)
+class PartitionedParquetCase:
+    left_path: str
+    right_path: str
+    left_df: pl.DataFrame
+    right_df: pl.DataFrame
+    left_lazy: pl.LazyFrame
+    right_lazy: pl.LazyFrame
+    view_df: pl.DataFrame
+
+
+def _with_zero_based_metadata(
+    df: pl.DataFrame | pl.LazyFrame,
+) -> pl.DataFrame | pl.LazyFrame:
+    df.config_meta.set(coordinate_system_zero_based=True)
+    return df
+
+
+def _sorted(df: pl.DataFrame) -> pl.DataFrame:
+    if not df.columns:
+        return df
+    return df.sort(df.columns)
+
+
+def _assert_same_rows(expected: pl.DataFrame, actual: pl.DataFrame) -> None:
+    pl.testing.assert_frame_equal(_sorted(expected), _sorted(actual))
+
+
+@contextmanager
+def _session_option(key: str, value: str):
+    original = pb.get_option(key)
+    pb.set_option(key, value)
+    try:
+        yield
+    finally:
+        restored = original if original is not None else OPTION_DEFAULTS.get(key)
+        if restored is None:
+            raise AssertionError(f"No restore value configured for option: {key}")
+        pb.set_option(key, restored)
+
+
+@contextmanager
+def _partitioned_range_options(
+    target_partitions: int,
+    *,
+    batch_size: int | None = None,
+):
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Coordinate system metadata is missing.*",
+            category=UserWarning,
+        )
+        with ExitStack() as stack:
+            stack.enter_context(
+                _session_option(TARGET_PARTITIONS_KEY, str(target_partitions))
+            )
+            stack.enter_context(
+                _session_option("datafusion.bio.coordinate_system_check", "false")
+            )
+            stack.enter_context(
+                _session_option("datafusion.bio.coordinate_system_zero_based", "true")
+            )
+            if batch_size is not None:
+                stack.enter_context(_session_option(BATCH_SIZE_KEY, str(batch_size)))
+            yield
+
+
+def _write_partitioned_parquet_case(tmp_path: Path) -> PartitionedParquetCase:
+    left_dir = tmp_path / "left"
+    right_dir = tmp_path / "right"
+    left_dir.mkdir()
+    right_dir.mkdir()
+
+    left_partitions = [
+        pl.DataFrame(
+            {
+                "contig": ["chr1", "chr1"],
+                "pos_start": [0, 20],
+                "pos_end": [10, 30],
+            }
+        ),
+        pl.DataFrame(
+            {
+                "contig": ["chr1"],
+                "pos_start": [8],
+                "pos_end": [25],
+            }
+        ),
+    ]
+    right_partitions = [
+        pl.DataFrame(
+            {
+                "contig": ["chr1"],
+                "pos_start": [5],
+                "pos_end": [10],
+            }
+        ),
+        pl.DataFrame(
+            {
+                "contig": ["chr1"],
+                "pos_start": [20],
+                "pos_end": [25],
+            }
+        ),
+    ]
+
+    for index, frame in enumerate(left_partitions):
+        frame.write_parquet(left_dir / f"part-{index:02d}.parquet")
+    for index, frame in enumerate(right_partitions):
+        frame.write_parquet(right_dir / f"part-{index:02d}.parquet")
+
+    left_glob = str(left_dir / "*.parquet")
+    right_glob = str(right_dir / "*.parquet")
+
+    left_df = _with_zero_based_metadata(pl.concat(left_partitions, rechunk=True))
+    right_df = _with_zero_based_metadata(pl.concat(right_partitions, rechunk=True))
+    left_lazy = _with_zero_based_metadata(pl.scan_parquet(left_glob))
+    right_lazy = _with_zero_based_metadata(pl.scan_parquet(right_glob))
+    view_df = _with_zero_based_metadata(
+        pl.DataFrame(
+            {
+                "chrom": ["chr1"],
+                "start": [0],
+                "end": [40],
+            }
+        )
+    )
+
+    return PartitionedParquetCase(
+        left_path=left_glob,
+        right_path=right_glob,
+        left_df=left_df,
+        right_df=right_df,
+        left_lazy=left_lazy,
+        right_lazy=right_lazy,
+        view_df=view_df,
+    )
+
+
+def _run_merge(case: PartitionedParquetCase, input_mode: str) -> pl.DataFrame:
+    if input_mode == "dataframe":
+        return pb.merge(case.left_df, cols=COLUMNS, output_type="polars.DataFrame")
+    if input_mode == "path":
+        return pb.merge(case.left_path, cols=COLUMNS, output_type="polars.DataFrame")
+    if input_mode == "lazy":
+        return pb.merge(
+            case.left_lazy,
+            cols=COLUMNS,
+            output_type="polars.LazyFrame",
+        ).collect(engine="streaming")
+    raise ValueError(f"Unsupported input mode: {input_mode}")
+
+
+def _run_complement(case: PartitionedParquetCase, input_mode: str) -> pl.DataFrame:
+    if input_mode == "dataframe":
+        return pb.complement(
+            case.left_df,
+            view_df=case.view_df,
+            cols=COLUMNS,
+            view_cols=VIEW_COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "path":
+        return pb.complement(
+            case.left_path,
+            view_df=case.view_df,
+            cols=COLUMNS,
+            view_cols=VIEW_COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "lazy":
+        return pb.complement(
+            case.left_lazy,
+            view_df=case.view_df,
+            cols=COLUMNS,
+            view_cols=VIEW_COLUMNS,
+            output_type="polars.LazyFrame",
+        ).collect(engine="streaming")
+    raise ValueError(f"Unsupported input mode: {input_mode}")
+
+
+def _run_subtract(case: PartitionedParquetCase, input_mode: str) -> pl.DataFrame:
+    if input_mode == "dataframe":
+        return pb.subtract(
+            case.left_df,
+            case.right_df,
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "path":
+        return pb.subtract(
+            case.left_path,
+            case.right_path,
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "lazy":
+        return pb.subtract(
+            case.left_lazy,
+            case.right_lazy,
+            cols1=COLUMNS,
+            cols2=COLUMNS,
+            output_type="polars.LazyFrame",
+        ).collect(engine="streaming")
+    raise ValueError(f"Unsupported input mode: {input_mode}")
+
+
+def _run_cluster(case: PartitionedParquetCase, input_mode: str) -> pl.DataFrame:
+    if input_mode == "dataframe":
+        return pb.cluster(
+            case.left_df,
+            cols=COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "path":
+        return pb.cluster(
+            case.left_path,
+            cols=COLUMNS,
+            output_type="polars.DataFrame",
+        )
+    if input_mode == "lazy":
+        return pb.cluster(
+            case.left_lazy,
+            cols=COLUMNS,
+            output_type="polars.LazyFrame",
+        ).collect(engine="streaming")
+    raise ValueError(f"Unsupported input mode: {input_mode}")
+
+
+@pytest.mark.parametrize(
+    ("name", "runner", "expected"),
+    [
+        ("merge", _run_merge, EXPECTED_MERGE),
+        ("complement", _run_complement, EXPECTED_COMPLEMENT),
+        ("subtract", _run_subtract, EXPECTED_SUBTRACT),
+        ("cluster", _run_cluster, EXPECTED_CLUSTER),
+    ],
+    ids=["merge", "complement", "subtract", "cluster"],
+)
+def test_partitioned_regression_case_matches_expected_rows_for_single_partition_dataframes(
+    tmp_path: Path,
+    name: str,
+    runner,
+    expected: pl.DataFrame,
+):
+    case = _write_partitioned_parquet_case(tmp_path)
+
+    with _partitioned_range_options(1):
+        result = runner(case, "dataframe")
+
+    assert result.height == expected.height, (
+        f"{name} single-partition dataframe control produced the wrong row count: "
+        f"expected {expected.height}, got {result.height}"
+    )
+    _assert_same_rows(expected, result)
+
+
+@pytest.mark.parametrize(
+    ("name", "runner", "expected"),
+    [
+        ("merge", _run_merge, EXPECTED_MERGE),
+        ("complement", _run_complement, EXPECTED_COMPLEMENT),
+        ("subtract", _run_subtract, EXPECTED_SUBTRACT),
+        ("cluster", _run_cluster, EXPECTED_CLUSTER),
+    ],
+    ids=["merge", "complement", "subtract", "cluster"],
+)
+@pytest.mark.parametrize("input_mode", ["path", "lazy"], ids=["path", "lazyframe"])
+@pytest.mark.parametrize("target_partitions", [2, 4], ids=["tp2", "tp4"])
+def test_partitioned_multifile_range_operations_preserve_global_semantics(
+    tmp_path: Path,
+    name: str,
+    runner,
+    expected: pl.DataFrame,
+    input_mode: str,
+    target_partitions: int,
+):
+    case = _write_partitioned_parquet_case(tmp_path)
+    batch_size = 1 if name == "cluster" or input_mode == "lazy" else None
+
+    with _partitioned_range_options(target_partitions, batch_size=batch_size):
+        result = runner(case, input_mode)
+
+    assert result.height == expected.height, (
+        f"{name} row count changed when target_partitions={target_partitions} "
+        f"for {input_mode}: expected {expected.height}, got {result.height}"
+    )
+    _assert_same_rows(expected, result)

--- a/tests/test_vcf_write.py
+++ b/tests/test_vcf_write.py
@@ -93,6 +93,33 @@ class TestVcfWriteBasic:
             first_bytes = f.read(2)
         assert first_bytes == b"\x1f\x8b", "File should be gzip compressed"
 
+    @pytest.mark.parametrize("partitions", [2, 4, 8])
+    def test_write_vcf_preserves_row_order_when_session_is_partitioned(
+        self, tmp_path, partitions
+    ):
+        """Arrow-stream writes must not inherit partition fanout from the session."""
+        input_path = f"{DATA_DIR}/io/vcf/single_sample_collision.vcf"
+        output_path = tmp_path / f"collision_tp{partitions}.vcf"
+        original_target_partitions = pb.get_option(
+            "datafusion.execution.target_partitions"
+        )
+
+        try:
+            pb.set_option("datafusion.execution.target_partitions", str(partitions))
+            df = pb.read_vcf(input_path)
+            rows_written = pb.write_vcf(df, str(output_path))
+        finally:
+            pb.set_option(
+                "datafusion.execution.target_partitions", original_target_partitions
+            )
+
+        assert rows_written == 2
+
+        df_back = pb.read_vcf(str(output_path))
+        assert df_back["start"].to_list() == [100, 200]
+        assert df_back["DP"].to_list() == [50, 60]
+        assert df_back["fmt_DP"].to_list() == [20, 30]
+
 
 class TestVcfRoundTrip:
     """Round-trip tests for VCF read-write-read."""


### PR DESCRIPTION
## Summary
- fan out LazyFrame-backed Arrow C streams into `target_partitions` when registering `StreamingTable` inputs
- keep the single-stream path for `target_partitions=1` and expose a small Rust debug helper for partition-count assertions
- avoid building a throwaway stream for LazyFrame schema inference and support mixed `LazyFrame + DataFrame` / `LazyFrame + path` inputs in the LazyFrame execution path
- add regression coverage for partition counts, result equivalence across all range operations, mixed-input cases, and bounded-buffer prefix consumption

## Validation
- `env -u CONDA_PREFIX .venv/bin/python -m pytest tests/test_lazyframe_partitioning.py tests/test_streaming.py tests/test_user_scenario.py -q`
- pre-commit hooks during commit: `isort`, `black`, `cargo check`, `fmt`

Closes #370