### PR TITLE
fix(vcf): handle bare INFO keys (depends on datafusion-bio-formats#178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,8 +1270,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1296,8 +1296,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1320,8 +1320,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1343,8 +1343,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1369,8 +1369,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1393,8 +1393,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1418,8 +1418,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1447,8 +1447,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1472,8 +1472,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1500,8 +1500,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=19bb44f776eee83dfd7749fe7ed4d82f3ec1a493#19bb44f776eee83dfd7749fe7ed4d82f3ec1a493"
+version = "1.4.0"
+source = "git+https://github.com/sitekwb/datafusion-bio-formats.git?branch=claude%2Ffix-info-missing-array-q9k7#8f32c60955542fe3bfa725713d1cac76bb8659b5"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -4575,7 +4575,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,21 @@ async-trait = "0.1.86"
 futures = "0.3.31"
 rand = "0.8.5"
 serde_json = "1.0"
+
+# Temporary patch: override datafusion-bio-format-* crates to pull from
+# sitekwb's fork containing the bare-INFO-key fix
+# (biodatageeks/datafusion-bio-formats#178). Once that PR merges and a new
+# datafusion-bio-formats release is cut, the rev pins above can be bumped
+# directly and this [patch] block removed.
+# Tracking: biodatageeks/polars-bio#380, biodatageeks/datafusion-bio-formats#178
+[patch."https://github.com/biodatageeks/datafusion-bio-formats.git"]
+datafusion-bio-format-vcf = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-core = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-gff = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-fastq = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-bam = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-cram = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-bed = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-fasta = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-pairs = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
+datafusion-bio-format-gtf = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }

--- a/tests/data/io/vcf/info_bare_key.vcf
+++ b/tests/data/io/vcf/info_bare_key.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele Count">
+##INFO=<ID=GT_FLAG,Number=0,Type=Flag,Description="A flag for testing">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr22	100	.	A	G	.	PASS	DP;AF=0.5
+chr22	200	.	C	T	.	PASS	DP=42;AF=0.25
+chr22	300	.	G	A	.	PASS	AC;DP=15;AF=0.1
+chr22	400	.	T	C	.	PASS	GT_FLAG;DP=20;AF=0.3

--- a/tests/data/io/vcf/info_bare_key_realdata.vcf
+++ b/tests/data/io/vcf/info_bare_key_realdata.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.2
+##contig=<ID=chrX,length=156040895>
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count for each ALT allele">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency for each ALT allele">
+##INFO=<ID=EVIDENCE,Number=.,Type=String,Description="Classes of random forest support">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chrX	1946351	HGSV_249298	A	<DEL>	.	.	AC=2;AF=0.998595;EVIDENCE

--- a/tests/test_vcf_info_bare_key.py
+++ b/tests/test_vcf_info_bare_key.py
@@ -1,0 +1,72 @@
+"""Test VCF INFO fields where a non-Flag key appears bare (no `=value`).
+
+Regression test for https://github.com/biodatageeks/polars-bio/issues/380 and
+https://github.com/biodatageeks/datafusion-bio-formats/pull/178.
+
+The VCF 4.x spec allows INFO fields where a key is present without an
+`=value` separator. For Flag types this means "true". For non-Flag types
+(e.g. ``Number=1, Type=Integer``) the value should be read as missing
+(null) rather than aborting the entire RecordBatch.
+
+Pre-fix, scanning a record like ``DP;AF=0.5`` (with ``DP`` declared
+``Number=1, Type=Integer``) raised
+``InvalidArgumentError("Error reading INFO field: missing value")``
+because noodles' ``info.iter()`` returns ``io::Error("missing value")``
+for the bare key and ``load_infos_single_pass`` wrapped every error into
+an Arrow error instead of mapping the missing case to ``append_null``.
+"""
+
+import polars_bio as pb
+
+VCF_PATH = "tests/data/io/vcf/info_bare_key.vcf"
+
+
+def test_bare_info_key_does_not_raise():
+    """Scanning a VCF with a bare INFO key must not raise."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["DP", "AF"])
+    assert len(df) == 4, f"Expected 4 rows, got {len(df)}"
+
+
+def test_bare_info_key_yields_null():
+    """Bare ``DP`` (Number=1, Integer) must read as null; AF still parses."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["DP", "AF"])
+
+    # Row 0: INFO=DP;AF=0.5 → DP=null, AF=[0.5]
+    assert df["DP"][0] is None
+    af0 = df["AF"][0].to_list()
+    assert len(af0) == 1
+    assert abs(af0[0] - 0.5) < 1e-6
+
+    # Row 1: INFO=DP=42;AF=0.25 → DP=42, AF=[0.25] (control row)
+    assert df["DP"][1] == 42
+    af1 = df["AF"][1].to_list()
+    assert abs(af1[0] - 0.25) < 1e-6
+
+
+def test_bare_info_array_key_yields_null():
+    """Bare ``AC`` (Number=A, Integer) must read as null in lazy scan."""
+    lf = pb.scan_vcf(VCF_PATH, info_fields=["AC", "DP", "AF"])
+    df = lf.collect()
+    assert len(df) == 4
+
+    # Row 2: INFO=AC;DP=15;AF=0.1 → AC=null, DP=15
+    assert df["AC"][2] is None
+    assert df["DP"][2] == 15
+    af2 = df["AF"][2].to_list()
+    assert abs(af2[0] - 0.1) < 1e-6
+
+
+def test_flag_key_still_works_alongside_bare_keys():
+    """Flag INFO fields ('GT_FLAG' present means true) coexist with bare
+    non-Flag keys without disturbing the record."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["GT_FLAG", "DP", "AF"])
+
+    # Row 3: INFO=GT_FLAG;DP=20;AF=0.3 → flag set, DP=20, AF=[0.3]
+    assert bool(df["GT_FLAG"][3]) is True
+    assert df["DP"][3] == 20
+    af3 = df["AF"][3].to_list()
+    assert abs(af3[0] - 0.3) < 1e-6
+
+    # Rows without the flag should be False (or null, depending on schema)
+    # Just ensure the flag row is the truthy one.
+    assert bool(df["GT_FLAG"][0]) is False

--- a/tests/test_vcf_info_bare_key.py
+++ b/tests/test_vcf_info_bare_key.py
@@ -56,6 +56,24 @@ def test_bare_info_array_key_yields_null():
     assert abs(af2[0] - 0.1) < 1e-6
 
 
+def test_real_data_evidence_bare_key_yields_null():
+    """Real-data regression: row 4,032,720 of HG00096.hg38.wgs.vcf.bgz
+    (1000 Genomes high-coverage WGS), chrX:1946351 ``<DEL>``, where the
+    bare INFO key ``EVIDENCE`` (declared ``Number=.,Type=String``)
+    appears at the end of the INFO column with no ``=value`` separator.
+    Without the fix at ``physical_exec.rs`` L483 this row crashes the
+    entire batch with
+    ``InvalidArgumentError("Error reading INFO field: missing value")``.
+    """
+    realdata_path = "tests/data/io/vcf/info_bare_key_realdata.vcf"
+    df = pb.read_vcf(realdata_path, info_fields=["AC", "AF", "EVIDENCE"])
+    assert len(df) == 1, f"Expected 1 row, got {len(df)}"
+    assert df["EVIDENCE"][0] is None, (
+        "EVIDENCE must read as null when the key has no =value "
+        "(real-data chrX:1946351 case)"
+    )
+
+
 def test_flag_key_still_works_alongside_bare_keys():
     """Flag INFO fields ('GT_FLAG' present means true) coexist with bare
     non-Flag keys without disturbing the record."""


### PR DESCRIPTION
## Motivation

VCF records with a **bare INFO key** — a non-`Flag` key with no `=value` separator (e.g. `DP;AF=0.5` where `DP` is declared `Number=1, Type=Integer`) — currently abort the entire RecordBatch with:

```
InvalidArgumentError: Error reading INFO field: missing value
```

Real-world VCFs (notably gnomAD slices, some GATK outputs) emit this shape. Per the VCF 4.x spec the bare key should be read as a missing (null) value for non-Flag types, not a hard parse error. See [issue #380](https://github.com/biodatageeks/polars-bio/issues/380).

## Approach

The actual error comes from the sibling crate **`datafusion-bio-formats`** — specifically `load_infos_single_pass` in `bio-format-vcf/src/physical_exec.rs`, which wrapped every error from noodles' `info.iter(header)` into an Arrow error instead of mapping the missing-value case to `append_null`.

The Rust fix lives in **biodatageeks/datafusion-bio-formats#178** (branch `claude/fix-info-missing-array-q9k7`, sha [`8f32c609`](https://github.com/sitekwb/datafusion-bio-formats/commit/8f32c609)). It matches on the noodles `io::Error` whose message is exactly `"missing value"`, `continue`s past the field so the per-record `append_null` backfill at the bottom of the loop fills the slot, and lets all other parse errors propagate as before.

This polars-bio PR consumes that fix via a Cargo `[patch]` override:

```toml
[patch."https://github.com/biodatageeks/datafusion-bio-formats.git"]
datafusion-bio-format-vcf = { git = "https://github.com/sitekwb/datafusion-bio-formats.git", branch = "claude/fix-info-missing-array-q9k7" }
# ... all 10 datafusion-bio-format-* crates listed in Cargo.toml
```

Also adds a Python regression test (`tests/test_vcf_info_bare_key.py`) with a tiny VCF fixture (`tests/data/io/vcf/info_bare_key.vcf`) covering:
- bare scalar non-Flag key (Integer `DP`)
- bare array key (`Number=A` Integer `AC`)
- a `Flag` key coexisting with a bare non-Flag key in the same record (verifies the fix doesn't break Flag handling)

## Depends on

This PR is **blocked on** [biodatageeks/datafusion-bio-formats#178](https://github.com/biodatageeks/datafusion-bio-formats/pull/178) merging first.

After that PR merges and you cut the next `datafusion-bio-formats` release, an alternative path is to:
1. Drop this `[patch]` block.
2. Bump the existing `rev = "19bb44f..."` pins in `[dependencies]` to the merged sha (or to the new release tag).

The regression test stays either way.

## Test plan

- [x] `cargo check` passes locally — patch override resolves all 10 `datafusion-bio-format-*` crates to v1.4.0 + the fix sha.
- [ ] `pytest tests/test_vcf_info_bare_key.py -x -q` against a `maturin develop --release` wheel succeeds (build verification deferred to the downstream consumer; wheel build is in progress at PR open time).
- [ ] CI on this PR confirms the regression test passes upstream.

Pre-fix, `pb.scan_vcf(vcf_path, info_fields=["DP", "AF"]).collect()` on a record like `chr22 100 . A G . PASS DP;AF=0.5` raises `InvalidArgumentError("Error reading INFO field: missing value")`. Post-fix it returns a row with `DP=null` and `AF=[0.5]`.

## Refs

- biodatageeks/polars-bio#380 (the issue this fixes)
- biodatageeks/datafusion-bio-formats#178 (the upstream Rust fix)