### PR TITLE
fix(vcf): consume bare INFO key parser fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,8 +1369,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1395,8 +1395,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1419,8 +1419,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1442,8 +1442,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1468,8 +1468,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1492,8 +1492,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1517,8 +1517,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1546,8 +1546,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1571,8 +1571,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1599,8 +1599,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.5.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=014b248462205216d9a7016fbdb6ba03f7c0fcdb#014b248462205216d9a7016fbdb6ba03f7c0fcdb"
+version = "1.5.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "014b248462205216d9a7016fbdb6ba03f7c0fcdb" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "148c64469d162ead6ca6cf3f31bb72bf43c64896" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4", default-features = false }

--- a/tests/data/io/vcf/info_bare_key.vcf
+++ b/tests/data/io/vcf/info_bare_key.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.3
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency">
+##INFO=<ID=ALLELE_ID,Number=.,Type=String,Description="Allele identifiers">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	100	rs1	A	T	60	PASS	DP;AF=0.5;ALLELE_ID=alt1;DB
+chr1	200	rs2	G	C	80	PASS	DP=42;AF;ALLELE_ID=alt2
+chr1	300	rs3	C	T	70	PASS	DP=7;AF=0.2;ALLELE_ID
+chr1	400	rs4	T	G	90	PASS	DP=9;AF=0.3;ALLELE_ID=alt4;DB

--- a/tests/data/io/vcf/info_bare_key_realdata.vcf
+++ b/tests/data/io/vcf/info_bare_key_realdata.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.2
+##contig=<ID=chrX,length=156040895>
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count for each ALT allele">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency for each ALT allele">
+##INFO=<ID=EVIDENCE,Number=.,Type=String,Description="Classes of random forest support">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chrX	1946351	HGSV_249298	A	<DEL>	.	.	AC=2;AF=0.998595;EVIDENCE

--- a/tests/data/io/vcf/info_invalid_flag_value.vcf
+++ b/tests/data/io/vcf/info_invalid_flag_value.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.3
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	100	rs1	A	T	60	PASS	DB=unexpected_payload

--- a/tests/test_vcf_info_bare_keys.py
+++ b/tests/test_vcf_info_bare_keys.py
@@ -1,0 +1,71 @@
+"""Regression tests for bare non-Flag VCF INFO keys.
+
+Tracks https://github.com/biodatageeks/polars-bio/issues/380 and the upstream
+fix in https://github.com/biodatageeks/datafusion-bio-formats/pull/183.
+"""
+
+import pytest
+
+import polars_bio as pb
+
+VCF_PATH = "tests/data/io/vcf/info_bare_key.vcf"
+REALDATA_VCF_PATH = "tests/data/io/vcf/info_bare_key_realdata.vcf"
+INVALID_FLAG_VCF_PATH = "tests/data/io/vcf/info_invalid_flag_value.vcf"
+
+
+def test_read_vcf_bare_scalar_info_key_yields_null():
+    """Bare scalar non-Flag INFO keys should be null, not scan errors."""
+    df = pb.read_vcf(VCF_PATH, info_fields=["DP", "AF", "ALLELE_ID", "DB"])
+
+    assert len(df) == 4
+    assert df["DP"][0] is None
+    assert df["DP"][1] == 42
+    assert df["DP"][2] == 7
+    assert df["DP"][3] == 9
+
+    af0 = df["AF"][0].to_list()
+    assert len(af0) == 1
+    assert abs(af0[0] - 0.5) < 1e-6
+
+    assert bool(df["DB"][0]) is True
+    assert bool(df["DB"][1]) is False
+    assert bool(df["DB"][2]) is False
+    assert bool(df["DB"][3]) is True
+
+
+def test_scan_vcf_bare_array_info_keys_yield_null():
+    """Bare Number=A and Number=. INFO keys should be null in lazy scans."""
+    df = pb.scan_vcf(VCF_PATH, info_fields=["DP", "AF", "ALLELE_ID"]).collect()
+
+    assert len(df) == 4
+    assert df["AF"][1] is None
+    assert df["ALLELE_ID"][2] is None
+
+    af2 = df["AF"][2].to_list()
+    assert len(af2) == 1
+    assert abs(af2[0] - 0.2) < 1e-6
+
+
+def test_unrequested_bare_info_key_does_not_abort_projection():
+    """Bare INFO keys outside info_fields should not abort projected scans."""
+    df = pb.scan_vcf(VCF_PATH, info_fields=["AF"]).select(["chrom", "AF"]).collect()
+
+    assert len(df) == 4
+    assert df["chrom"][0] == "chr1"
+    assert df["AF"][1] is None
+
+
+def test_real_data_evidence_bare_key_yields_null():
+    """Real chrX:1946351 EVIDENCE bare key should parse as null."""
+    df = pb.read_vcf(REALDATA_VCF_PATH, info_fields=["AC", "AF", "EVIDENCE"])
+
+    assert len(df) == 1
+    assert df["AC"][0].to_list() == [2]
+    assert abs(df["AF"][0].to_list()[0] - 0.998595) < 1e-6
+    assert df["EVIDENCE"][0] is None
+
+
+def test_explicit_value_for_flag_still_errors():
+    """Flag INFO fields with explicit values should still fail."""
+    with pytest.raises(Exception, match="invalid flag|Error reading INFO field"):
+        pb.read_vcf(INVALID_FLAG_VCF_PATH, info_fields=["DB"])


### PR DESCRIPTION
## Summary

Consumes the upstream VCF parser fix from biodatageeks/datafusion-bio-formats#183 by bumping all `datafusion-bio-format-*` rev pins from `014b248...` to `04d3777...`.

Adds `polars-bio` regression coverage for biodatageeks/polars-bio#380 so `pb.read_vcf()` and `pb.scan_vcf().collect()` no longer abort on bare non-Flag INFO keys such as the real `EVIDENCE` row at `chrX:1946351`.

## Tests

Added `tests/test_vcf_info_bare_keys.py` plus small VCF fixtures covering:

- bare scalar non-Flag INFO key -> null
- bare `Number=A` INFO key -> null
- bare `Number=.` INFO key -> null
- bare unrequested INFO key does not abort projected lazy scans
- real `EVIDENCE` row from #380 -> null
- explicit value for a Flag field still errors

Verified locally:

```text
# red before rev bump: 4 failed, 1 passed with InvalidArgumentError("Error reading INFO field: missing value")
env -u CONDA_PREFIX uv run maturin develop
uv run pytest tests/test_vcf_info_bare_keys.py -q
uv run ruff format --check tests/test_vcf_info_bare_keys.py
uv run ruff check tests/test_vcf_info_bare_keys.py
uv run pytest tests/test_vcf_info_bare_keys.py tests/test_vcf_info_missing_values.py -q
cargo check
```

Current green results:

```text
tests/test_vcf_info_bare_keys.py: 5 passed
tests/test_vcf_info_bare_keys.py tests/test_vcf_info_missing_values.py: 10 passed
cargo check: finished successfully
```

## Dependency

This PR should merge after biodatageeks/datafusion-bio-formats#183.