### PR TITLE
chore: Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
       benchmark_config: ${{ steps.benchmark-config.outputs.config }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -137,7 +137,7 @@ jobs:
         run: echo "/home/gha/.local/bin" >> $GITHUB_PATH
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history for tag identification
 
@@ -162,7 +162,7 @@ jobs:
           echo "Using alert threshold: $THRESHOLD%"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -178,7 +178,7 @@ jobs:
           brew install bedtools jq
 
       - name: Cache polars-bio-bench repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: polars-bio-bench
           key: polars-bio-bench-${{ hashFiles('**/lockfiles') }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Restore benchmark test data cache
         id: cache-benchmark-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/polars-bio-bench
           key: polars-bio-bench-data-${{ hashFiles('polars-bio-bench/conf/benchmark_small.yaml') }}
@@ -295,7 +295,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -351,7 +351,7 @@ jobs:
 
       - name: Save benchmark test data cache
         if: success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/polars-bio-bench
           key: ${{ steps.cache-benchmark-data.outputs.cache-primary-key }}
@@ -373,7 +373,7 @@ jobs:
           cat runner_info.json
 
       - name: Upload benchmark results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results-${{ matrix.runner }}
           path: |
@@ -390,13 +390,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: all-results/
           pattern: benchmark-results-*
@@ -720,7 +720,7 @@ jobs:
 
       - name: Comment PR with comparison results
         if: steps.find_pr.outputs.has_pr == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -40,8 +40,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Set up Rust
@@ -59,8 +59,8 @@ jobs:
         target: [x86_64]
         python-version: [ "3.11", "3.12", "3.13", "3.14" ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@v8.1.0
@@ -84,8 +84,8 @@ jobs:
       matrix:
         target: [x86_64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build wheels
@@ -99,7 +99,7 @@ jobs:
           RUSTFLAGS: "-Dwarnings -Ctarget-cpu=${{ env.TARGET_CPU }}"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-manylinux-${{ matrix.target }}
           path: dist
@@ -109,8 +109,8 @@ jobs:
       matrix:
         target: [x64]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           architecture: ${{ matrix.target }}
@@ -123,7 +123,7 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings -Ctarget-cpu=${{ env.TARGET_CPU }}"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-win-${{ matrix.target }}
           path: dist
@@ -139,8 +139,8 @@ jobs:
           - target: aarch64
             apple_cpu_target: "apple-m1"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build wheels
@@ -152,21 +152,21 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings -Clink-arg=-undefined -Clink-arg=dynamic_lookup -Ctarget-cpu=${{ matrix.apple_cpu_target }}"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-sdist
           path: dist
@@ -185,9 +185,9 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
     - name: Generate artifact attestation
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@v3
       with:
         subject-path: 'wheels-*/*'
     - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2


### PR DESCRIPTION
## Summary
- Update GitHub-owned workflow actions to Node 24-capable major versions.
- Refresh checkout, setup-python, cache, artifact, github-script, and attestation actions across tracked workflows.
- Avoid temporary Node 24 opt-in/legacy opt-out environment flags.

## Verification
- `rg -n "actions/(checkout@(v3|v4)|setup-python@(v4|v5)|upload-artifact@v4|download-artifact@v4|cache(@|/restore@|/save@)v4|github-script@v7|attest-build-provenance@v1)|node20|node16|node12" .github/workflows --glob "!update_bioconda_recipe.yml" || true`
- `ruby -e 'require "yaml"; files=%w[.github/workflows/benchmark.yml .github/workflows/claude-code-review.yml .github/workflows/publish_documentation.yml .github/workflows/publish_to_pypi.yml .github/workflows/release.yml]; files.each { |f| YAML.load_file(f); puts "ok #{f}" }'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'property "comparison" is not defined' .github/workflows/benchmark.yml .github/workflows/claude-code-review.yml .github/workflows/publish_documentation.yml .github/workflows/publish_to_pypi.yml .github/workflows/release.yml`\n\n## Notes\n- `benchmark.yml` has an existing unrelated actionlint warning for `steps.comparison.outputs.regression_detected`; this PR leaves that behavior unchanged.\n- The untracked `.github/workflows/update_bioconda_recipe.yml` file was not included in this PR.