### PR TITLE
feat: Add VCF Zarr describe and registration APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,8 +1369,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1395,8 +1395,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1419,8 +1419,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1442,8 +1442,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1468,8 +1468,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1492,8 +1492,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1517,8 +1517,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1546,8 +1546,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1571,8 +1571,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1599,8 +1599,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=94d4d6811eaa8d967ae2ae99485a91ca80d82e6d#94d4d6811eaa8d967ae2ae99485a91ca80d82e6d"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=22f62a19f5550ccb660bc196547c142eefe35ac3#22f62a19f5550ccb660bc196547c142eefe35ac3"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1469,7 +1469,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1572,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.5.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=3c15b7a3bdda4e65768984c6c6a67b5679141e19#3c15b7a3bdda4e65768984c6c6a67b5679141e19"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=280947c1ffdad825b336a02c74143d15e2d2a85b#280947c1ffdad825b336a02c74143d15e2d2a85b"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "94d4d6811eaa8d967ae2ae99485a91ca80d82e6d" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "148c64469d162ead6ca6cf3f31bb72bf43c64896" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "22f62a19f5550ccb660bc196547c142eefe35ac3" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "148c64469d162ead6ca6cf3f31bb72bf43c64896" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,16 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "3c15b7a3bdda4e65768984c6c6a67b5679141e19" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "280947c1ffdad825b336a02c74143d15e2d2a85b" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "148c64469d162ead6ca6cf3f31bb72bf43c64896" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97375ac981bd075d77f7b1da3d04364894283be4", default-features = false }

--- a/docs/features.md
+++ b/docs/features.md
@@ -1003,6 +1003,21 @@ pb.register_vcf("gs://gcp-public-data--gnomad/release/4.1/genome_sv/gnomad.v4.1.
 pb.sql("SELECT * FROM gnomad_sv WHERE SVTYPE = 'DEL' AND SVLEN > 1000").limit(3).collect()
 ```
 
+Local VCF Zarr stores can be registered with the same SQL context:
+
+```python
+import polars_bio as pb
+
+pb.register_vcf_zarr(
+    "cohort.vcz",
+    "cohort",
+    info_fields=["DP"],
+    format_fields=["GT"],
+    samples=["HG001"],
+)
+pb.sql('SELECT chrom, start, "DP", genotypes FROM cohort LIMIT 5').collect()
+```
+
 ### Accessing registered tables
 
 You can access registered tables programmatically using the `ctx.table()` method, which returns a DataFusion DataFrame:
@@ -1038,6 +1053,7 @@ Quickly inspect BAM/CRAM file schemas without reading the entire file:
 
 ```python
 import polars_bio as pb
+import polars as pl
 
 # Get schema information for BAM file
 schema = pb.describe_bam("file.bam")
@@ -1059,6 +1075,13 @@ print(schema)  # Shows 14 columns including tags
 
 # CRAM schema
 schema = pb.describe_cram("file.cram")
+
+# VCF and local VCF Zarr describe output includes INFO and FORMAT rows.
+vcf_schema = pb.describe_vcf("variants.vcf")
+vcz_schema = pb.describe_vcf_zarr("cohort.vcz")
+format_fields = vcf_schema.filter(pl.col("field_type") == "FORMAT")
+
+# VCF describe columns: name, field_type, data_type, description.
 ```
 
 ### BAM Optional Tags

--- a/docs/features.md
+++ b/docs/features.md
@@ -1077,6 +1077,7 @@ print(schema)  # Shows 14 columns including tags
 schema = pb.describe_cram("file.cram")
 
 # VCF and local VCF Zarr describe output includes INFO and FORMAT rows.
+# Nested FORMAT data is reported by its selectable column name, `genotypes`.
 vcf_schema = pb.describe_vcf("variants.vcf")
 vcz_schema = pb.describe_vcf_zarr("cohort.vcz")
 format_fields = vcf_schema.filter(pl.col("field_type") == "FORMAT")

--- a/openspec/changes/add-vcf-zarr-support/specs/vcf-zarr/spec.md
+++ b/openspec/changes/add-vcf-zarr-support/specs/vcf-zarr/spec.md
@@ -156,13 +156,16 @@ The system SHALL provide explicit `describe_vcf_zarr` and `register_vcf_zarr` AP
 #### Scenario: Describe VCF fields
 - **WHEN** a user calls `describe_vcf` with a supported VCF path
 - **THEN** the system returns a Polars `DataFrame` with `name`, `field_type`, `data_type`, and `description` columns
-- **AND** each row describes one discovered INFO or FORMAT field
+- **AND** each row describes one discovered INFO field or exposed FORMAT column
+- **AND** nested multisample FORMAT data is described as the exposed `genotypes` column
+- **AND** single-sample FORMAT rows use the exposed column name, including collision names such as `fmt_DP`
 - **AND** `field_type` is `INFO` for INFO rows and `FORMAT` for FORMAT rows.
 
 #### Scenario: Describe VCF Zarr fields
 - **WHEN** a user calls `describe_vcf_zarr` with a supported local VCF Zarr path
 - **THEN** the system returns a Polars `DataFrame` with `name`, `field_type`, `data_type`, and `description` columns
-- **AND** each row describes one discovered INFO or FORMAT field
+- **AND** each row describes one discovered INFO field or exposed FORMAT column
+- **AND** nested FORMAT data is described as the exposed `genotypes` column
 - **AND** `field_type` is `INFO` for INFO rows and `FORMAT` for FORMAT rows.
 
 #### Scenario: Register VCF Zarr for SQL

--- a/openspec/changes/add-vcf-zarr-support/specs/vcf-zarr/spec.md
+++ b/openspec/changes/add-vcf-zarr-support/specs/vcf-zarr/spec.md
@@ -149,3 +149,23 @@ The initial implementation SHALL support local filesystem VCF Zarr stores and SH
 #### Scenario: Unsupported remote path
 - **WHEN** a user provides an unsupported remote path
 - **THEN** the reader fails with an error that remote VCF Zarr storage is not supported in this version.
+
+### Requirement: VCF And VCF Zarr Describe And Register APIs
+The system SHALL provide explicit `describe_vcf_zarr` and `register_vcf_zarr` APIs that follow the existing VCF API conventions for local VCF Zarr stores, and SHALL include FORMAT fields in VCF describe output.
+
+#### Scenario: Describe VCF fields
+- **WHEN** a user calls `describe_vcf` with a supported VCF path
+- **THEN** the system returns a Polars `DataFrame` with `name`, `field_type`, `data_type`, and `description` columns
+- **AND** each row describes one discovered INFO or FORMAT field
+- **AND** `field_type` is `INFO` for INFO rows and `FORMAT` for FORMAT rows.
+
+#### Scenario: Describe VCF Zarr fields
+- **WHEN** a user calls `describe_vcf_zarr` with a supported local VCF Zarr path
+- **THEN** the system returns a Polars `DataFrame` with `name`, `field_type`, `data_type`, and `description` columns
+- **AND** each row describes one discovered INFO or FORMAT field
+- **AND** `field_type` is `INFO` for INFO rows and `FORMAT` for FORMAT rows.
+
+#### Scenario: Register VCF Zarr for SQL
+- **WHEN** a user calls `register_vcf_zarr` with a supported local VCF Zarr path and table name
+- **THEN** the system registers the VCF Zarr store as a DataFusion table
+- **AND** SQL queries can read core, INFO, and requested FORMAT columns through the logical VCF schema.

--- a/openspec/changes/add-vcf-zarr-support/tasks.md
+++ b/openspec/changes/add-vcf-zarr-support/tasks.md
@@ -24,7 +24,11 @@
 - [x] 2.6 Add predicate type metadata for VCF Zarr logical columns.
 - [x] 2.7 Preserve coordinate-system and source metadata.
 - [x] 2.8 Add Python tests for API behavior, projection pushdown, predicate pushdown, sample pruning, and metadata.
-- [ ] 2.9 Add user documentation and API examples.
+- [x] 2.9 Extend `describe_vcf` output to include FORMAT rows with a `field_type` discriminator.
+- [x] 2.10 Add `describe_vcf_zarr` Rust/PyO3 and Python API support.
+- [x] 2.11 Add `register_vcf_zarr` Python SQL registration API support.
+- [x] 2.12 Add Python tests for `describe_vcf`, `describe_vcf_zarr`, and `register_vcf_zarr`.
+- [x] 2.13 Add user documentation and API examples.
 
 ## 3. Typed VCZ Values and Genotype Encoding
 

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -48,6 +48,7 @@ if "POLARS_FORCE_NEW_STREAMING" not in os.environ:
 register_gff = data_processing.register_gff
 register_gtf = data_processing.register_gtf
 register_vcf = data_processing.register_vcf
+register_vcf_zarr = data_processing.register_vcf_zarr
 register_fastq = data_processing.register_fastq
 register_bam = data_processing.register_bam
 register_sam = data_processing.register_sam
@@ -59,6 +60,7 @@ register_view = data_processing.register_view
 sql = data_processing.sql
 
 describe_vcf = data_input.describe_vcf
+describe_vcf_zarr = data_input.describe_vcf_zarr
 describe_bam = data_input.describe_bam
 describe_sam = data_input.describe_sam
 describe_cram = data_input.describe_cram
@@ -144,6 +146,7 @@ __all__ = [
     "print_metadata_summary",
     # I/O functions
     "describe_vcf",
+    "describe_vcf_zarr",
     "describe_bam",
     "describe_sam",
     "describe_cram",
@@ -187,6 +190,7 @@ __all__ = [
     "register_gff",
     "register_gtf",
     "register_vcf",
+    "register_vcf_zarr",
     "register_fastq",
     "register_bam",
     "register_sam",

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -33,6 +33,7 @@ from polars_bio.polars_bio import (
     py_describe_bam,
     py_describe_cram,
     py_describe_vcf,
+    py_describe_vcf_zarr,
     py_from_polars,
     py_get_table_schema,
     py_read_sql,
@@ -1858,6 +1859,16 @@ class IOOperations:
             compression_type=compression_type,
         )
         return py_describe_vcf(ctx, path, object_storage_options).to_polars()
+
+    @staticmethod
+    def describe_vcf_zarr(path: str) -> pl.DataFrame:
+        """
+        Describe VCF Zarr INFO and FORMAT schema.
+
+        Parameters:
+            path: The path to the local VCF Zarr store directory.
+        """
+        return py_describe_vcf_zarr(ctx, path).to_polars()
 
     @staticmethod
     def from_polars(name: str, df: Union[pl.DataFrame, pl.LazyFrame]) -> None:

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -14,6 +14,7 @@ from polars_bio.polars_bio import (
     PyObjectStorageOptions,
     ReadOptions,
     VcfReadOptions,
+    VcfZarrReadOptions,
     py_describe_vcf,
     py_from_polars,
     py_read_sql,
@@ -22,7 +23,7 @@ from polars_bio.polars_bio import (
     py_register_view,
 )
 
-from .context import ctx
+from .context import _resolve_zero_based, ctx
 from .io import (
     _cleanse_fields,
     _lazy_scan,
@@ -99,7 +100,12 @@ class SQL:
                     enable_request_payer=enable_request_payer,
                     compression_type=compression_type,
                 )
-                all_info_fields = vcf_schema_df.select("name").to_series().to_list()
+                all_info_fields = (
+                    vcf_schema_df.filter(pl.col("field_type") == "INFO")
+                    .select("name")
+                    .to_series()
+                    .to_list()
+                )
             except Exception:
                 # Fallback to empty list if unable to get info fields
                 all_info_fields = []
@@ -110,6 +116,39 @@ class SQL:
         )
         read_options = ReadOptions(vcf_read_options=vcf_read_options)
         py_register_table(ctx, path, name, InputFormat.Vcf, read_options)
+
+    @staticmethod
+    def register_vcf_zarr(
+        path: str,
+        name: Union[str, None] = None,
+        info_fields: Union[list[str], None] = None,
+        format_fields: Union[list[str], None] = None,
+        use_zero_based: Union[bool, None] = None,
+        samples: Union[list[str], None] = None,
+        genotype_encoding_raw: bool = True,
+    ) -> None:
+        """
+        Register a local VCF Zarr store as a Datafusion table.
+
+        Parameters:
+            path: The path to the VCF Zarr store directory.
+            name: The table name. If *None*, the table name is generated from the path.
+            info_fields: Optional list of INFO field names to include. If *None*, local INFO arrays are discovered automatically. Use [] to disable INFO fields.
+            format_fields: Optional list of FORMAT field names to include. If *None*, local FORMAT arrays are discovered automatically. Use [] to disable FORMAT fields.
+            use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None, uses the global configuration.
+            samples: Optional list of sample names to include.
+            genotype_encoding_raw: If True, output GT as raw typed allele calls. If False, output VCF-style GT strings.
+        """
+        zero_based = _resolve_zero_based(use_zero_based)
+        vcf_zarr_read_options = VcfZarrReadOptions(
+            info_fields=info_fields,
+            format_fields=format_fields,
+            samples=samples,
+            zero_based=zero_based,
+            genotype_encoding_raw=genotype_encoding_raw,
+        )
+        read_options = ReadOptions(vcf_zarr_read_options=vcf_zarr_read_options)
+        py_register_table(ctx, path, name, InputFormat.VcfZarr, read_options)
 
     @staticmethod
     def register_gff(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,35 @@ fn py_describe_vcf(
     })
 }
 
+#[pyfunction]
+#[pyo3(signature = (py_ctx, path))]
+fn py_describe_vcf_zarr(
+    py: Python<'_>,
+    py_ctx: &PyBioSessionContext,
+    path: String,
+) -> PyResult<PyDataFrame> {
+    py.allow_threads(|| {
+        let rt = Runtime::new()?;
+        let ctx = &py_ctx.ctx;
+        let rb = datafusion_bio_format_vcf::zarr::describe_fields(path).map_err(|e| {
+            PyRuntimeError::new_err(format!("VCF Zarr schema extraction failed: {e}"))
+        })?;
+        let mem_table = MemTable::try_new(rb.schema().clone(), vec![vec![rb]])
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to create memory table: {e}")))?;
+        let table_name = format!("vcf_zarr_schema_{}", rand::random::<u32>());
+        let df = rt
+            .block_on(async {
+                ctx.register_table(table_name.clone(), Arc::new(mem_table))
+                    .map_err(|e| format!("Failed to register table: {e}"))?;
+                ctx.table(table_name)
+                    .await
+                    .map_err(|e| format!("Failed to get table: {e}"))
+            })
+            .map_err(PyRuntimeError::new_err)?;
+        Ok(PyDataFrame::new(df))
+    })
+}
+
 fn quote_sql_identifier(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
 }
@@ -796,6 +825,7 @@ fn polars_bio(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_read_sql, m)?)?;
     m.add_function(wrap_pyfunction!(py_get_table_schema, m)?)?;
     m.add_function(wrap_pyfunction!(py_describe_vcf, m)?)?;
+    m.add_function(wrap_pyfunction!(py_describe_vcf_zarr, m)?)?;
     m.add_function(wrap_pyfunction!(py_register_view, m)?)?;
     m.add_function(wrap_pyfunction!(py_from_polars, m)?)?;
     m.add_function(wrap_pyfunction!(py_write_table, m)?)?;

--- a/tests/test_io_vcf.py
+++ b/tests/test_io_vcf.py
@@ -3,7 +3,7 @@ from _expected import DATA_DIR
 import polars_bio as pb
 
 
-def test_describe_vcf_includes_info_and_format_fields():
+def test_describe_vcf_includes_info_and_nested_format_column():
     schema = pb.describe_vcf(f"{DATA_DIR}/io/vcf/multisample.vcf")
 
     assert schema.columns == ["name", "field_type", "data_type", "description"]
@@ -12,8 +12,22 @@ def test_describe_vcf_includes_info_and_format_fields():
         (row["field_type"], row["name"]): row["data_type"] for row in schema.to_dicts()
     }
     assert rows[("INFO", "AF")] == "Float"
+    assert rows[("FORMAT", "genotypes")] == "Struct"
+    assert ("FORMAT", "GT") not in rows
+    assert ("FORMAT", "DP") not in rows
+
+
+def test_describe_vcf_single_sample_format_names_match_selectable_columns():
+    schema = pb.describe_vcf(f"{DATA_DIR}/io/vcf/single_sample_collision.vcf")
+
+    assert schema.columns == ["name", "field_type", "data_type", "description"]
+
+    rows = {
+        (row["field_type"], row["name"]): row["data_type"] for row in schema.to_dicts()
+    }
     assert rows[("FORMAT", "GT")] == "String"
-    assert rows[("FORMAT", "DP")] == "Integer"
+    assert rows[("FORMAT", "fmt_DP")] == "Integer"
+    assert ("FORMAT", "DP") not in rows
 
 
 class TestIOVCF:

--- a/tests/test_io_vcf.py
+++ b/tests/test_io_vcf.py
@@ -3,6 +3,19 @@ from _expected import DATA_DIR
 import polars_bio as pb
 
 
+def test_describe_vcf_includes_info_and_format_fields():
+    schema = pb.describe_vcf(f"{DATA_DIR}/io/vcf/multisample.vcf")
+
+    assert schema.columns == ["name", "field_type", "data_type", "description"]
+
+    rows = {
+        (row["field_type"], row["name"]): row["data_type"] for row in schema.to_dicts()
+    }
+    assert rows[("INFO", "AF")] == "Float"
+    assert rows[("FORMAT", "GT")] == "String"
+    assert rows[("FORMAT", "DP")] == "Integer"
+
+
 class TestIOVCF:
     """Tests for VCF read functionality."""
 

--- a/tests/test_vcf_zarr_io.py
+++ b/tests/test_vcf_zarr_io.py
@@ -333,8 +333,9 @@ def test_describe_vcf_zarr_returns_info_and_format_schema(tmp_path):
     assert data_type_by_field[("INFO", "AF")] == "Float"
     assert data_type_by_field[("INFO", "DB")] == "Flag"
     assert data_type_by_field[("INFO", "DP")] == "Integer"
-    assert data_type_by_field[("FORMAT", "DP")] == "Integer"
-    assert data_type_by_field[("FORMAT", "GT")] == "Integer"
+    assert data_type_by_field[("FORMAT", "genotypes")] == "Struct"
+    assert ("FORMAT", "DP") not in data_type_by_field
+    assert ("FORMAT", "GT") not in data_type_by_field
 
 
 def test_read_vcf_zarr_collects_dataframe():

--- a/tests/test_vcf_zarr_io.py
+++ b/tests/test_vcf_zarr_io.py
@@ -322,6 +322,21 @@ def test_scan_vcf_zarr_sets_source_metadata():
     assert metadata["source_path"] == str(VCF_ZARR)
 
 
+def test_describe_vcf_zarr_returns_info_and_format_schema(tmp_path):
+    store = _sampled_format_store(tmp_path)
+    schema = pb.describe_vcf_zarr(str(store)).sort(["name", "field_type"])
+
+    assert schema.columns == ["name", "field_type", "data_type", "description"]
+    data_type_by_field = {
+        (row["field_type"], row["name"]): row["data_type"] for row in schema.to_dicts()
+    }
+    assert data_type_by_field[("INFO", "AF")] == "Float"
+    assert data_type_by_field[("INFO", "DB")] == "Flag"
+    assert data_type_by_field[("INFO", "DP")] == "Integer"
+    assert data_type_by_field[("FORMAT", "DP")] == "Integer"
+    assert data_type_by_field[("FORMAT", "GT")] == "Integer"
+
+
 def test_read_vcf_zarr_collects_dataframe():
     df = pb.read_vcf_zarr(str(VCF_ZARR))
 
@@ -416,6 +431,39 @@ def test_scan_vcf_zarr_prunes_unrequested_format_arrays(tmp_path):
         .select("genotypes")
         .collect()
     )
+
+    assert df.height == 1
+    assert df["genotypes"].to_list()[0] == {"DP": [2000]}
+
+
+def test_register_vcf_zarr_queries_core_and_info_columns():
+    pb.register_vcf_zarr(str(VCF_ZARR), name="test_vcz_register", info_fields=["DP"])
+
+    df = (
+        pb.sql(
+            'SELECT chrom, start, "DP" FROM test_vcz_register WHERE start >= 5000100'
+        )
+        .head(2)
+        .collect()
+    )
+
+    assert df.columns == ["chrom", "start", "DP"]
+    assert df.height == 2
+    assert df.schema["DP"] == pl.Int8
+
+
+def test_register_vcf_zarr_queries_requested_format_fields(tmp_path):
+    store = _sampled_format_store(tmp_path)
+    pb.register_vcf_zarr(
+        str(store),
+        name="test_vcz_format_register",
+        format_fields=["DP"],
+        samples=["22"],
+    )
+
+    df = pb.sql(
+        "SELECT genotypes FROM test_vcz_format_register WHERE start = 5000100"
+    ).collect()
 
     assert df.height == 1
     assert df["genotypes"].to_list()[0] == {"DP": [2000]}


### PR DESCRIPTION
## Summary
- Add public `describe_vcf_zarr()` and `register_vcf_zarr()` APIs.
- Extend `describe_vcf()` output to include INFO and FORMAT rows with `name`, `field_type`, `data_type`, and `description` columns.
- Pin `datafusion-bio-formats` dependencies to commit `280947c1ffdad825b336a02c74143d15e2d2a85b` from biodatageeks/datafusion-bio-formats#184.

## Test Plan
- `cargo check`
- `uv run pytest tests/test_vcf_zarr_io.py tests/test_io_vcf.py::test_describe_vcf_includes_info_and_format_fields -q`
- `openspec validate add-vcf-zarr-support --strict`
- `git diff --check HEAD`

## Dependency
- Requires biodatageeks/datafusion-bio-formats#184