### PR TITLE
fix: GFF/GTF attribute predicate fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1395,8 +1395,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1421,8 +1421,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1444,8 +1444,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1466,8 +1466,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1492,8 +1492,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1515,8 +1515,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1539,8 +1539,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1567,8 +1567,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1592,8 +1592,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1620,8 +1620,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=78f776fbbe0f92215de6700407fc8b9a93acdb13#78f776fbbe0f92215de6700407fc8b9a93acdb13"
+version = "1.8.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.1#11df16f43098270bbc2954d43aa850052aa95536"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1650,8 +1650,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=35a6a6e41c6212c8e031d3beb7f917591e589475#35a6a6e41c6212c8e031d3beb7f917591e589475"
+version = "0.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1664,8 +1664,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-ranges"
-version = "0.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=35a6a6e41c6212c8e031d3beb7f917591e589475#35a6a6e41c6212c8e031d3beb7f917591e589475"
+version = "0.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+checksum = "be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1802,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+checksum = "331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a579c3bd290c66ea4b269493e75e8a3ed42c9c895a651f10210a29538aee50c4"
+checksum = "49dda81c79b6ba57b1853a9158abc66eb85a3aa1cede0c517dabec6d8a4ed3aa"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+checksum = "9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1869,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+checksum = "ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+checksum = "95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1929,9 +1929,9 @@ checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+checksum = "9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1988,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ffi"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95173344d04ba62755c949bf44f8d1a6e4414cf6392a635db96c07e711b9a3c"
+checksum = "4b8250f7cdf463a0ad145f41d7508bcfa54c9b9f027317e599f0331097e3cc38"
 dependencies = [
  "abi_stable",
  "arrow",
@@ -2018,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+checksum = "04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
 dependencies = [
  "ahash",
  "arrow",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+checksum = "463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d"
 dependencies = [
  "ahash",
  "arrow",
@@ -2292,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a387aaef949dc16bb6abc81bd1af850ec7449183aef011214f9724957495738"
+checksum = "677ee4448a010ed5faeff8d73ff78972c2ace59eff3cd7bd15833a1dafa00492"
 dependencies = [
  "arrow",
  "chrono",
@@ -2331,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2406,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+checksum = "12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6092,8 +6092,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superintervals"
-version = "0.10.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=35a6a6e41c6212c8e031d3beb7f917591e589475#35a6a6e41c6212c8e031d3beb7f917591e589475"
+version = "0.13.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
 dependencies = [
  "aligned-vec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pyo3 = { version = "0.28.3", features = ["extension-module", "abi3"] }
 pyo3-log = "0.13.3"
 
 
-datafusion = { version = "53.1.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
+datafusion = { version = "=53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
 arrow-schema = "58.3.0"
 arrow-array = { version = "58.3.0", features = ["ffi"] }
@@ -25,19 +25,19 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "78f776fbbe0f92215de6700407fc8b9a93acdb13" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.1" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "35a6a6e41c6212c8e031d3beb7f917591e589475" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "35a6a6e41c6212c8e031d3beb7f917591e589475", default-features = false }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0", default-features = false }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/docs/superpowers/plans/2026-06-26-gff-gtf-attributes-sentinel.md
+++ b/docs/superpowers/plans/2026-06-26-gff-gtf-attributes-sentinel.md
@@ -1,0 +1,736 @@
+# GFF/GTF `attributes` Sentinel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the GFF/GTF readers emit the nested `attributes` `List<Struct>` column *and* flattened attribute fields from a single registration, so polars-bio queries that mix raw `attributes` with parsed fields return correct results instead of raising.
+
+**Architecture:** Treat the literal name `"attributes"` as a sentinel inside the reader's Mode 2 (`attr_fields=Some`). When present, the schema emits a nested `List<Struct{tag,value}>` column for it (instead of `Utf8`), and the flattened loader populates that slot with the fully-parsed attribute struct array. polars-bio then requests `attr_fields = parsed_fields + ["attributes"]` whenever a query needs both representations, and its existing pushdown/fallback pipeline resolves every column by name.
+
+**Tech Stack:** Rust (DataFusion, Arrow) in `datafusion-bio-formats`; Python + PyO3 (`maturin`) in `polars-bio`; pytest; cargo test.
+
+## Global Constraints
+
+- Upstream branch base: rev `94d4d6811eaa8d967ae2ae99485a91ca80d82e6d` (the rev polars-bio pins today), to isolate this feature from unrelated `master` changes.
+- Mirror every reader change in BOTH `datafusion/bio-format-gff` and `datafusion/bio-format-gtf`.
+- Do NOT change behavior of `attr_fields=None` (Mode 1) or of Mode 2 without the sentinel. The change must be purely additive.
+- The sentinel name is exactly the string `"attributes"` (matches polars-bio's `STATIC`/raw column name).
+- GFF attribute parsing URL-decodes (`%3B %3D %26 %2C %09`); GTF does not. Reuse each crate's existing `parse_*_attributes_to_vec` — do not reimplement parsing.
+- The nested `List<Struct>` produced for the sentinel must be byte-identical to that crate's Mode 1 `attributes` column (same struct fields `tag: Utf8 non-null`, `value: Utf8 nullable`).
+- Out of scope: the unimplemented remote-GFF attribute path (`get_remote_gff_stream` appends nulls today — leave as-is); the `object_storage_options.unwrap()` panic; DataFusion pushdown of `List<Struct>` predicates.
+- Local clone for dev: `/Users/mwiewior/research/git/datafusion-bio-formats` (workspace containing all `bio-format-*` crates).
+- polars-bio build: `maturin develop --release` after any Rust dependency change.
+
+---
+
+## File Structure
+
+**Upstream `datafusion-bio-formats` (branch `feat/attributes-sentinel-in-flattened` off `94d4d68`):**
+- `datafusion/bio-format-gff/src/table_provider.rs` — `determine_schema_on_demand` Mode 2 loop (sentinel field type).
+- `datafusion/bio-format-gff/src/physical_exec.rs` — `set_attribute_builders` (sentinel builder) + `load_attributes_unnest_from_string` (sentinel slot fill).
+- `datafusion/bio-format-gff/tests/attribute_projection_test.rs` — new GFF sentinel tests.
+- `datafusion/bio-format-gtf/src/table_provider.rs` — same Mode 2 loop change.
+- `datafusion/bio-format-gtf/src/physical_exec.rs` — `set_attribute_builders` + `load_attributes_unnest_from_string` (GTF tuple shape `.1`).
+- `datafusion/bio-format-gtf/tests/gtf_read_test.rs` — new GTF sentinel tests.
+
+**`polars-bio` (branch `feat/gff-gtf-attributes-sentinel` off the PR branch `issue-396-gff-gtf-predicate-fallback`):**
+- `Cargo.toml` — dependency source for the ten `datafusion-bio-format-*` crates (path override for dev → commit SHA pin at the end).
+- `polars_bio/io.py` — `AnnotationLazyFrameWrapper.select()` `_attr` computation (replace the `NotImplementedError`).
+- `tests/test_filter_select_attributes_bug_fix.py` — rewrite the two interim "raises" tests; add positive GFF tests.
+- `tests/test_io_gtf.py` — add positive GTF test.
+
+---
+
+## PHASE A — Upstream reader (`datafusion-bio-formats`)
+
+### Task 1: GFF — sentinel schema, builder, and loader
+
+**Files:**
+- Modify: `datafusion/bio-format-gff/src/table_provider.rs` (`determine_schema_on_demand`, Mode 2 `Some(attrs)` arm ~lines 66–87)
+- Modify: `datafusion/bio-format-gff/src/physical_exec.rs` (`set_attribute_builders` lines 167–178; `load_attributes_unnest_from_string` final loop lines 272–289)
+- Test: `datafusion/bio-format-gff/tests/attribute_projection_test.rs`
+
+**Interfaces:**
+- Consumes: existing `parse_gff_attributes_to_vec(&str) -> Vec<Attribute>` (physical_exec.rs:181), `OptionalField::new(&DataType, usize)`, `OptionalField::append_array_struct(Vec<Attribute>)` (core table_utils.rs:171).
+- Produces: a `GffTableProvider` registered with `attr_fields = Some(vec!["ID","attributes"])` whose schema has `ID: Utf8` at index 8 and `attributes: List<Struct{tag,value}>` at index 9, both populated correctly.
+
+- [ ] **Step 1: Create the branch off the pinned rev**
+
+```bash
+cd /Users/mwiewior/research/git/datafusion-bio-formats
+git fetch origin
+git checkout -b feat/attributes-sentinel-in-flattened 94d4d6811eaa8d967ae2ae99485a91ca80d82e6d
+```
+
+- [ ] **Step 2: Write the failing GFF test**
+
+Append to `datafusion/bio-format-gff/tests/attribute_projection_test.rs` (reuses `create_test_gff_file_with_attributes`, `create_object_storage_options` already in that file; add any missing `use` for `DataType`):
+
+```rust
+#[tokio::test]
+async fn test_attributes_sentinel_with_flattened_field(
+) -> Result<(), Box<dyn std::error::Error>> {
+    use datafusion::arrow::array::{Array, ListArray, StringArray};
+    use datafusion::arrow::datatypes::DataType;
+
+    let file_path = create_test_gff_file_with_attributes().await?;
+    let table = GffTableProvider::new(
+        file_path.clone(),
+        Some(vec!["ID".to_string(), "attributes".to_string()]),
+        Some(create_object_storage_options()),
+        true,
+    )?;
+
+    // Schema: 8 static + ID(Utf8) + attributes(List<Struct>)
+    let schema = table.schema();
+    assert_eq!(schema.fields().len(), 10);
+    assert_eq!(schema.field(8).name(), "ID");
+    assert_eq!(schema.field(8).data_type(), &DataType::Utf8);
+    assert_eq!(schema.field(9).name(), "attributes");
+    assert!(matches!(schema.field(9).data_type(), DataType::List(_)));
+
+    let ctx = SessionContext::new();
+    ctx.register_table("g", Arc::new(table))?;
+    let results = ctx
+        .sql("SELECT \"ID\", attributes FROM g")
+        .await?
+        .collect()
+        .await?;
+    let batch = &results[0];
+
+    let id = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(id.value(0), "gene1");
+
+    let attrs = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    // Row 0 has a non-null, non-empty nested attributes list
+    assert!(attrs.is_valid(0));
+    assert!(attrs.value(0).len() >= 2);
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+Run: `cd /Users/mwiewior/research/git/datafusion-bio-formats && cargo test -p datafusion-bio-format-gff test_attributes_sentinel_with_flattened_field -- --nocapture`
+Expected: FAIL — schema field 9 is `Utf8` (not `List`) and/or the `attributes` column is all-null.
+
+- [ ] **Step 4: Implement the schema sentinel**
+
+In `table_provider.rs`, replace the Mode 2 `Some(attrs)` loop body:
+
+```rust
+        Some(attrs) => {
+            // Mode 2: Projection - add requested attributes as individual columns
+            // All GFF attributes are treated as nullable strings for simplicity
+            for attr_name in &attrs {
+                if attr_name == "attributes" {
+                    // Sentinel: emit the nested attributes column alongside
+                    // flattened fields (identical to Mode 1's attributes field).
+                    fields.push(Field::new(
+                        "attributes",
+                        DataType::List(FieldRef::from(Box::new(Field::new(
+                            "item",
+                            DataType::Struct(Fields::from(vec![
+                                Field::new("tag", DataType::Utf8, false),
+                                Field::new("value", DataType::Utf8, true),
+                            ])),
+                            true,
+                        )))),
+                        true,
+                    ));
+                } else {
+                    fields.push(Field::new(
+                        attr_name,
+                        DataType::Utf8, // All GFF attributes are strings
+                        true,           // Attributes can be null
+                    ));
+                }
+            }
+            debug!(
+                "GFF Schema Mode 2 (Projection): 8 static fields + {} attribute fields = {} columns total",
+                attrs.len(),
+                8 + attrs.len()
+            );
+        }
+```
+
+- [ ] **Step 5: Implement the builder sentinel**
+
+In `physical_exec.rs`, replace `set_attribute_builders`:
+
+```rust
+fn set_attribute_builders(
+    batch_size: usize,
+    attr_fields: &[String],
+    attribute_builders: &mut (Vec<String>, Vec<DataType>, Vec<OptionalField>),
+) {
+    for attr_name in attr_fields {
+        if attr_name == "attributes" {
+            // Sentinel: a nested List<Struct> builder (matches the Mode 1 builder).
+            let dt = DataType::List(FieldRef::new(Field::new(
+                "attribute",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("tag", DataType::Utf8, false),
+                    Field::new("value", DataType::Utf8, true),
+                ])),
+                true,
+            )));
+            let field = OptionalField::new(&dt, batch_size).unwrap();
+            attribute_builders.0.push(attr_name.clone());
+            attribute_builders.1.push(dt);
+            attribute_builders.2.push(field);
+        } else {
+            let field = OptionalField::new(&DataType::Utf8, batch_size).unwrap();
+            attribute_builders.0.push(attr_name.clone());
+            attribute_builders.1.push(DataType::Utf8);
+            attribute_builders.2.push(field);
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Implement the loader sentinel**
+
+In `physical_exec.rs`, replace the final `for i in 0..attribute_builders.2.len()` loop inside `load_attributes_unnest_from_string` (lines 272–289):
+
+```rust
+    for i in 0..attribute_builders.2.len() {
+        if let Some(indices) = &projected_attribute_indices
+            && !indices.contains(&i)
+        {
+            attribute_builders.2[i].append_null()?;
+            continue;
+        }
+
+        if attribute_builders.0[i] == "attributes" {
+            // Sentinel slot: append the fully-parsed nested attributes struct.
+            let attributes = parse_gff_attributes_to_vec(attributes_str);
+            attribute_builders.2[i].append_array_struct(attributes)?;
+            continue;
+        }
+
+        if let Some(value) = attributes_map.get(&attribute_builders.0[i]) {
+            attribute_builders.2[i].append_string(value)?;
+        } else {
+            attribute_builders.2[i].append_null()?;
+        }
+    }
+```
+
+- [ ] **Step 7: Run the test, verify it passes**
+
+Run: `cargo test -p datafusion-bio-format-gff test_attributes_sentinel_with_flattened_field -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 8: Run the full GFF crate test suite (no regressions)**
+
+Run: `cargo test -p datafusion-bio-format-gff`
+Expected: PASS (existing Mode 1 / Mode 2 tests unchanged).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add datafusion/bio-format-gff/src/table_provider.rs \
+        datafusion/bio-format-gff/src/physical_exec.rs \
+        datafusion/bio-format-gff/tests/attribute_projection_test.rs
+git commit -m "feat(gff): emit nested attributes alongside flattened fields via 'attributes' sentinel"
+```
+
+---
+
+### Task 2: GFF — confirm sentinel on the indexed path
+
+**Files:**
+- Test: `datafusion/bio-format-gff/tests/indexed_read_test.rs`
+
+**Interfaces:**
+- Consumes: the Task 1 changes (the indexed stream `get_indexed_gff_stream` calls the same `set_attribute_builders` + `load_attributes_unnest_from_string`, so it should work without further edits).
+- Produces: proof the sentinel works through the indexed (`.tbi`) reader.
+
+- [ ] **Step 1: Write a failing/guard test on the indexed path**
+
+Append to `datafusion/bio-format-gff/tests/indexed_read_test.rs` a test that registers the bundled `multi_chrom.gff3.gz` provider with `attr_fields = Some(vec!["ID".into(), "attributes".into()])`, runs a query that triggers the indexed stream (the same pattern existing tests in that file use), and asserts `attributes` is a `List` column and non-null for at least one row, while `ID` is a populated `Utf8`. Match the existing file's provider-construction and region-query helpers (read the top of the file first and copy its setup verbatim, substituting the `attr_fields` argument).
+
+- [ ] **Step 2: Run it**
+
+Run: `cargo test -p datafusion-bio-format-gff --test indexed_read_test`
+Expected: PASS (Task 1 already routes indexed attribute loading through the shared helper). If it FAILS because the indexed stream parses attributes differently, fix `get_indexed_gff_stream` (physical_exec.rs ~1391–1403) to call the same loader, then re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add datafusion/bio-format-gff/tests/indexed_read_test.rs
+git commit -m "test(gff): cover attributes sentinel on the indexed read path"
+```
+
+---
+
+### Task 3: GTF — sentinel schema, builder, and loader
+
+**Files:**
+- Modify: `datafusion/bio-format-gtf/src/table_provider.rs` (`determine_schema_on_demand`, Mode 2 `Some(attrs)` arm)
+- Modify: `datafusion/bio-format-gtf/src/physical_exec.rs` (`set_attribute_builders` lines 366–376; `load_attributes_unnest_from_string` final loop lines 437–450)
+- Test: `datafusion/bio-format-gtf/tests/gtf_read_test.rs`
+
+**Interfaces:**
+- Consumes: existing `parse_gtf_attributes_to_vec(&str) -> Vec<Attribute>` (physical_exec.rs:378), `OptionalField::append_array_struct`. Note GTF's `attribute_builders` is a **2-tuple** `(Vec<String>, Vec<OptionalField>)` — builders are `.1` (not `.2`).
+- Produces: a `GtfTableProvider` registered with `attr_fields = Some(vec!["gene_id","attributes"])` whose schema has `gene_id: Utf8` then `attributes: List<Struct>`, both populated. Works for local + remote + indexed (all share `GtfBatchCollector`).
+
+- [ ] **Step 1: Write the failing GTF test**
+
+Append to `datafusion/bio-format-gtf/tests/gtf_read_test.rs` (reuses `test_gtf_path`, `setup_ctx`; uses `gene_id` which exists in `tests/test.gtf`):
+
+```rust
+#[tokio::test]
+async fn test_gtf_attributes_sentinel_with_flattened_field() {
+    use datafusion::arrow::array::{Array, ListArray, StringArray};
+    use datafusion::arrow::datatypes::DataType;
+
+    let table = GtfTableProvider::new(
+        test_gtf_path(),
+        Some(vec!["gene_id".to_string(), "attributes".to_string()]),
+        None,
+        true,
+    )
+    .unwrap();
+
+    let schema = table.schema();
+    assert_eq!(schema.fields().len(), 10);
+    assert_eq!(schema.field(8).name(), "gene_id");
+    assert_eq!(schema.field(8).data_type(), &DataType::Utf8);
+    assert_eq!(schema.field(9).name(), "attributes");
+    assert!(matches!(schema.field(9).data_type(), DataType::List(_)));
+
+    let ctx = SessionContext::new();
+    ctx.register_table("gtf", Arc::new(table)).unwrap();
+    let results = ctx
+        .sql("SELECT \"gene_id\", attributes FROM gtf LIMIT 1")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+    let batch = &results[0];
+
+    let gene_id = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert!(!gene_id.value(0).is_empty());
+
+    let attrs = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap();
+    assert!(attrs.is_valid(0));
+    assert!(attrs.value(0).len() >= 1);
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `cargo test -p datafusion-bio-format-gtf test_gtf_attributes_sentinel_with_flattened_field -- --nocapture`
+Expected: FAIL — field 9 is `Utf8` / `attributes` is null.
+
+- [ ] **Step 3: Implement the GTF schema sentinel**
+
+In `table_provider.rs`, replace the Mode 2 `Some(attrs)` loop:
+
+```rust
+        Some(attrs) => {
+            for attr_name in &attrs {
+                if attr_name == "attributes" {
+                    fields.push(Field::new(
+                        "attributes",
+                        DataType::List(FieldRef::from(Box::new(Field::new(
+                            "item",
+                            DataType::Struct(Fields::from(vec![
+                                Field::new("tag", DataType::Utf8, false),
+                                Field::new("value", DataType::Utf8, true),
+                            ])),
+                            true,
+                        )))),
+                        true,
+                    ));
+                } else {
+                    fields.push(Field::new(attr_name, DataType::Utf8, true));
+                }
+            }
+            debug!(
+                "GTF Schema Mode 2 (Projection): 8 static fields + {} attribute fields = {} columns total",
+                attrs.len(),
+                8 + attrs.len()
+            );
+        }
+```
+
+- [ ] **Step 4: Implement the GTF builder sentinel**
+
+In `physical_exec.rs`, replace `set_attribute_builders` (2-tuple shape):
+
+```rust
+fn set_attribute_builders(
+    batch_size: usize,
+    attr_fields: &[String],
+    attribute_builders: &mut (Vec<String>, Vec<OptionalField>),
+) {
+    for attr_name in attr_fields {
+        let field = if attr_name == "attributes" {
+            OptionalField::new(
+                &DataType::List(FieldRef::new(Field::new(
+                    "item",
+                    DataType::Struct(Fields::from(vec![
+                        Field::new("tag", DataType::Utf8, false),
+                        Field::new("value", DataType::Utf8, true),
+                    ])),
+                    true,
+                ))),
+                batch_size,
+            )
+            .unwrap()
+        } else {
+            OptionalField::new(&DataType::Utf8, batch_size).unwrap()
+        };
+        attribute_builders.0.push(attr_name.clone());
+        attribute_builders.1.push(field);
+    }
+}
+```
+
+- [ ] **Step 5: Implement the GTF loader sentinel**
+
+In `physical_exec.rs`, replace the final `for i in 0..attribute_builders.1.len()` loop inside `load_attributes_unnest_from_string`:
+
+```rust
+    for i in 0..attribute_builders.1.len() {
+        if let Some(indices) = &projected_attribute_indices
+            && !indices.contains(&i)
+        {
+            attribute_builders.1[i].append_null()?;
+            continue;
+        }
+
+        if attribute_builders.0[i] == "attributes" {
+            let attributes = parse_gtf_attributes_to_vec(attributes_str);
+            attribute_builders.1[i].append_array_struct(attributes)?;
+            continue;
+        }
+
+        if let Some(value) = attributes_map.get(&attribute_builders.0[i]) {
+            attribute_builders.1[i].append_string(value)?;
+        } else {
+            attribute_builders.1[i].append_null()?;
+        }
+    }
+```
+
+- [ ] **Step 6: Run the GTF test, verify it passes**
+
+Run: `cargo test -p datafusion-bio-format-gtf test_gtf_attributes_sentinel_with_flattened_field -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full GTF crate test suite**
+
+Run: `cargo test -p datafusion-bio-format-gtf`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add datafusion/bio-format-gtf/src/table_provider.rs \
+        datafusion/bio-format-gtf/src/physical_exec.rs \
+        datafusion/bio-format-gtf/tests/gtf_read_test.rs
+git commit -m "feat(gtf): emit nested attributes alongside flattened fields via 'attributes' sentinel"
+```
+
+---
+
+## PHASE B — polars-bio integration
+
+### Task 4: Build polars-bio against the local upstream branch
+
+**Files:**
+- Modify (dev-only, not committed in this task): `Cargo.toml`
+
+**Interfaces:**
+- Consumes: the local clone at `/Users/mwiewior/research/git/datafusion-bio-formats` checked out on `feat/attributes-sentinel-in-flattened`.
+- Produces: a polars-bio wheel built against the sentinel-capable reader, used by Tasks 5–6.
+
+- [ ] **Step 1: Create the polars-bio feature branch**
+
+```bash
+cd /Users/mwiewior/research/git/polars-bio
+git checkout issue-396-gff-gtf-predicate-fallback
+git checkout -b feat/gff-gtf-attributes-sentinel
+```
+
+- [ ] **Step 2: Point the ten bio-format deps at the local path**
+
+Add a `[patch."https://github.com/biodatageeks/datafusion-bio-formats.git"]` section to the end of `Cargo.toml` (keeps the existing `rev`-pinned lines untouched; patch redirects all of them to the local workspace):
+
+```toml
+[patch."https://github.com/biodatageeks/datafusion-bio-formats.git"]
+datafusion-bio-format-vcf = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-vcf" }
+datafusion-bio-format-core = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-core" }
+datafusion-bio-format-gff = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-gff" }
+datafusion-bio-format-fastq = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-fastq" }
+datafusion-bio-format-bam = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-bam" }
+datafusion-bio-format-cram = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-cram" }
+datafusion-bio-format-bed = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-bed" }
+datafusion-bio-format-fasta = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-fasta" }
+datafusion-bio-format-pairs = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-pairs" }
+datafusion-bio-format-gtf = { path = "/Users/mwiewior/research/git/datafusion-bio-formats/datafusion/bio-format-gtf" }
+```
+
+(If a `[patch]` redirect fails to resolve a crate, fall back to editing each `rev`-pinned line to `path = ...` directly. Verify crate dir names against `ls /Users/mwiewior/research/git/datafusion-bio-formats/datafusion`.)
+
+- [ ] **Step 3: Build**
+
+Run: `maturin develop --release`
+Expected: builds successfully against the local path.
+
+- [ ] **Step 4: Sanity-check no behavior change yet**
+
+Run: `python -m pytest tests/test_io_gtf.py tests/test_gff_eager_vs_lazy.py -q`
+Expected: PASS (reader change is additive; existing behavior unchanged).
+
+- [ ] **Step 5: Do NOT commit the dev path override.**
+
+The `[patch]` block is replaced by a committed `rev` pin in Task 6. Leave it uncommitted in the working tree for now.
+
+---
+
+### Task 5: polars-bio — request the sentinel and verify correct results
+
+**Files:**
+- Modify: `polars_bio/io.py` — `AnnotationLazyFrameWrapper.select()` `_attr` block (the `needs_raw_attributes`/`NotImplementedError` block added in PR #397).
+- Modify: `tests/test_filter_select_attributes_bug_fix.py` — rewrite the two "raises" tests; add positive tests.
+- Modify: `tests/test_io_gtf.py` — add a positive GTF test.
+
+**Interfaces:**
+- Consumes: the sentinel-capable reader (Task 4 build). `scan_columns`, `attr_cols`, `columns` already computed earlier in `select()`.
+- Produces: `select()` returns correct rows for mixed raw-`attributes` + parsed-field queries; no `NotImplementedError`.
+
+- [ ] **Step 1: Rewrite the two interim "raises" tests to assert correctness**
+
+In `tests/test_filter_select_attributes_bug_fix.py`, replace `test_raw_attributes_predicate_with_parsed_select_raises` and `test_parsed_predicate_with_raw_attributes_select_raises` with:
+
+```python
+    def test_raw_attributes_predicate_with_parsed_select(self, test_gff_file):
+        """Predicate on raw nested `attributes` + select a parsed field returns correct rows."""
+        # Select rows that carry a "Type" attribute (only gene rows do in the fixture).
+        has_type = pl.col("attributes").list.eval(
+            pl.element().struct.field("tag")
+        ).list.contains("Type")
+        lf = pb.scan_gff(test_gff_file).filter(has_type)
+
+        projected = lf.select("ID").collect()
+        oracle = lf.collect().select("ID")
+
+        pl.testing.assert_frame_equal(projected, oracle)
+        assert projected.height > 0
+        assert projected["ID"].null_count() == 0
+
+    def test_parsed_predicate_with_raw_attributes_select(self, test_gff_file):
+        """Predicate on a parsed field + select the raw nested `attributes` returns correct rows."""
+        flt = pl.col("ID").str.contains("GENE")
+        got = (
+            pb.scan_gff(test_gff_file, attr_fields=["ID"])
+            .filter(flt)
+            .select("attributes")
+            .collect()
+        )
+        expected_ids = (
+            pb.scan_gff(test_gff_file, attr_fields=["ID"])
+            .filter(flt)
+            .select("ID")
+            .collect()["ID"]
+            .to_list()
+        )
+
+        assert got.height == len(expected_ids)
+        assert got.height > 0
+        # Each returned nested attributes row contains its matching ID value.
+        recovered = (
+            got.select(
+                pl.col("attributes")
+                .list.eval(
+                    pl.element()
+                    .filter(pl.element().struct.field("tag") == "ID")
+                    .struct.field("value")
+                )
+                .list.first()
+                .alias("ID")
+            )["ID"]
+            .to_list()
+        )
+        assert recovered == expected_ids
+```
+
+- [ ] **Step 2: Add a projection-only test (the pre-existing crash)**
+
+Add to the same class:
+
+```python
+    def test_select_raw_attributes_and_parsed_field_together(self, test_gff_file):
+        """Selecting raw `attributes` and a parsed field together (no predicate) works."""
+        out = pb.scan_gff(test_gff_file).select(["attributes", "ID"]).collect()
+        assert set(out.columns) == {"attributes", "ID"}
+        assert out.height > 0
+        assert out["ID"].null_count() == 0
+        # attributes is the nested List<Struct> representation
+        assert out.schema["attributes"] == pl.List(
+            pl.Struct({"tag": pl.String, "value": pl.String})
+        )
+```
+
+- [ ] **Step 3: Add the GTF equivalent**
+
+Append to `tests/test_io_gtf.py` (follow that file's fixture/style; create a small GTF fixture inline if the module lacks one):
+
+```python
+def test_gtf_parsed_predicate_with_raw_attributes_select(tmp_path):
+    import polars as pl
+    import polars_bio as pb
+
+    gtf = tmp_path / "t.gtf"
+    gtf.write_text(
+        'chr1\ttest\tgene\t1\t9\t.\t+\t.\tgene_id "ENSG1"; gene_name "A";\n'
+        'chr1\ttest\tgene\t10\t19\t.\t+\t.\tgene_id "ENSG2"; gene_name "B";\n'
+    )
+    got = (
+        pb.scan_gtf(str(gtf), attr_fields=["gene_id"])
+        .filter(pl.col("gene_id") == "ENSG1")
+        .select("attributes")
+        .collect()
+    )
+    assert got.height == 1
+    recovered = got.select(
+        pl.col("attributes")
+        .list.eval(
+            pl.element()
+            .filter(pl.element().struct.field("tag") == "gene_id")
+            .struct.field("value")
+        )
+        .list.first()
+        .alias("gene_id")
+    )["gene_id"].to_list()
+    assert recovered == ["ENSG1"]
+```
+
+- [ ] **Step 4: Run the new tests, verify they FAIL (still raising NotImplementedError)**
+
+Run: `python -m pytest tests/test_filter_select_attributes_bug_fix.py -q -k "raw_attributes or parsed_predicate or together"`
+Expected: FAIL with `NotImplementedError` (the production code still raises).
+
+- [ ] **Step 5: Replace the `NotImplementedError` block with the sentinel `_attr` request**
+
+In `polars_bio/io.py`, replace the conflict block (the `needs_raw_attributes and attr_cols` `raise NotImplementedError(...)` plus the following `if needs_raw_attributes: _attr = None ...`) with:
+
+```python
+            needs_raw_attributes = "attributes" in scan_columns
+            if needs_raw_attributes and attr_cols:
+                # Request flattened fields AND the nested `attributes` column in a
+                # single registration (reader supports the "attributes" sentinel).
+                _attr = attr_cols + ["attributes"]
+            elif needs_raw_attributes:
+                _attr = None
+            elif attr_cols:
+                _attr = attr_cols
+            else:
+                _attr = []
+```
+
+Delete the explanatory comment block and the `raise NotImplementedError(...)` introduced in PR #397.
+
+- [ ] **Step 6: Run the new tests, verify they PASS**
+
+Run: `python -m pytest tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full regression suite from the PR**
+
+Run: `python -m pytest tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py tests/test_gff_eager_vs_lazy.py tests/test_optimization_bug_fix.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit (code + tests only — not Cargo.toml)**
+
+```bash
+git add polars_bio/io.py tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py
+git commit -m "feat: return correct results for mixed raw-attributes + parsed-field GFF/GTF queries"
+```
+
+---
+
+### Task 6: Pin the upstream commit and final verification
+
+**Files:**
+- Modify: `Cargo.toml` (replace dev path override with the new upstream commit SHA on all ten deps)
+
+**Interfaces:**
+- Consumes: the pushed upstream branch commit SHA.
+- Produces: a reproducible build pinned to the published reader commit; green full suite.
+
+- [ ] **Step 1: Push the upstream branch and capture the SHA**
+
+```bash
+cd /Users/mwiewior/research/git/datafusion-bio-formats
+git push -u origin feat/attributes-sentinel-in-flattened
+NEW_SHA=$(git rev-parse HEAD)
+echo "$NEW_SHA"
+```
+
+- [ ] **Step 2: Repin all ten deps in polars-bio `Cargo.toml`**
+
+Remove the `[patch...]` block added in Task 4. Update the ten `datafusion-bio-format-*` lines' `rev = "94d4d68..."` to `rev = "<NEW_SHA>"` (leave `datafusion-bio-function-*` lines untouched).
+
+- [ ] **Step 3: Rebuild against the pinned commit**
+
+Run: `cd /Users/mwiewior/research/git/polars-bio && maturin develop --release`
+Expected: builds from the git commit (no path override).
+
+- [ ] **Step 4: Full verification**
+
+Run: `python -m pytest tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py tests/test_gff_eager_vs_lazy.py tests/test_optimization_bug_fix.py -q`
+Then a broader smoke run: `python -m pytest tests/test_io_gff.py -q` (if present).
+Expected: PASS.
+
+- [ ] **Step 5: Commit the pin**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "build: pin datafusion-bio-formats to attributes-sentinel commit"
+```
+
+- [ ] **Step 6: Push and update PR #397 (or open a stacked PR)**
+
+```bash
+git push -u origin feat/gff-gtf-attributes-sentinel
+```
+Then reply on PR #397 summarizing that the `NotImplementedError` is replaced by the real fix, linking the upstream branch/commit. (Confirm with the user whether to retarget PR #397 onto this branch or open a follow-up PR.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Sentinel schema (both crates) → Tasks 1, 3. ✓
+- Sentinel execution/loader (both crates, all streams via shared helpers) → Tasks 1, 3; indexed path explicitly checked in Task 2. ✓
+- polars-bio `_attr` change replacing `NotImplementedError` → Task 5. ✓
+- Cargo.toml dev path override → commit SHA pin → Tasks 4, 6. ✓
+- TDD: every code change is preceded by a failing test (Rust Steps 2/3; Python Step 4) → ✓
+- Tests for both findings + projection-only + GTF + eager-vs-lazy → Task 5. ✓
+- Out-of-scope items (remote GFF stub, unwrap panic, List pushdown) explicitly excluded → Global Constraints. ✓
+
+**Placeholder scan:** Task 2 deliberately defers exact indexed-test setup to "copy the file's existing helpers" because that file's harness wasn't extracted verbatim; this is a read-then-mirror instruction, not a code placeholder. All production code steps contain complete code.
+
+**Type consistency:** GFF `attribute_builders` is the 3-tuple (`.0` names, `.1` types, `.2` builders); GTF is the 2-tuple (`.0` names, `.1` builders) — the loader/builder steps use `.2` for GFF and `.1` for GTF accordingly. Parse helpers: `parse_gff_attributes_to_vec` (GFF) vs `parse_gtf_attributes_to_vec` (GTF). Nested List child name matches each crate's existing Mode 1 (`"item"` in schema; builder `"attribute"` for GFF / `"item"` for GTF — identical to current working Mode 1, so `RecordBatch::try_new` tolerates it as it does today).

--- a/docs/superpowers/specs/2026-06-26-gff-gtf-attributes-sentinel-design.md
+++ b/docs/superpowers/specs/2026-06-26-gff-gtf-attributes-sentinel-design.md
@@ -1,0 +1,169 @@
+# GFF/GTF: emit nested `attributes` alongside flattened fields (sentinel design)
+
+- **Date:** 2026-06-26
+- **Status:** Approved (brainstorm) — ready for implementation plan
+- **Repos touched:** `datafusion-bio-formats` (upstream, Rust) + `polars-bio` (Python/Rust glue)
+- **Related:** PR #397 (`issue-396-gff-gtf-predicate-fallback`), issue #396
+- **Supersedes:** the interim `NotImplementedError` guard added to PR #397
+
+## Problem
+
+`AnnotationLazyFrameWrapper.select()` re-registers the GFF/GTF file to materialize
+attribute columns on demand. A single registration can expose **either** the raw
+nested `attributes` column **or** flattened attribute fields, never both. When a
+query needs both at once — the projection wants one representation and the deferred
+predicate the other — the registered table is missing a column and the query fails.
+
+Two reachable failures (both confirmed):
+
+1. `scan_gff().filter(<predicate on raw attributes>).select("ID")`
+   — table registered with `attr_fields=["ID"]`, raw `attributes` absent → fallback
+   select on `attributes` errors.
+2. `scan_gff(attr_fields=["ID"]).filter(pl.col("ID")...).select("attributes")`
+   — table registered with `attr_fields=None`, flattened `ID` absent → fallback
+   select/filter on `ID` errors.
+
+A projection-only variant `scan_gff().select(["attributes","ID"])` is the same
+root cause and already crashed before PR #397.
+
+PR #397 currently converts these into a clear `NotImplementedError`. This spec
+replaces that with a real fix that returns correct results.
+
+## Root cause (upstream reader)
+
+In `datafusion-bio-formats` the GFF/GTF readers have two mutually exclusive modes
+driven by `attr_fields` (see `table_provider.rs::determine_schema_on_demand` and
+`physical_exec.rs::get_local_gff` / object-store variant):
+
+- **Mode 1** (`attr_fields=None`): schema = 8 static columns + nested
+  `attributes` `List<Struct{tag: Utf8, value: Utf8}>`. Execution fills a "nested
+  builder".
+- **Mode 2** (`attr_fields=Some([...])`): schema = 8 static columns + one **Utf8**
+  column per requested field. Execution fills "flattened builders".
+
+A binary `unnest_enable` flag selects exactly one builder set at batch assembly.
+Requesting `attr_fields=["ID","attributes"]` today produces flattened `ID` plus an
+**all-null Utf8** `attributes` column, because the executor looks up a nonexistent
+attribute key literally named `"attributes"`.
+
+## Design
+
+### Mechanism: `"attributes"` as a sentinel in Mode 2
+
+When `attr_fields` (Mode 2) contains the literal name `"attributes"`, the reader
+emits the **nested `List<Struct>`** column for it (Mode-1 representation), in the
+positional slot matching its index in `attr_fields`, alongside the other flattened
+fields. The remaining names continue to flatten as today.
+
+This is purely additive: `attr_fields=None` and `attr_fields` without
+`"attributes"` are unchanged.
+
+### Upstream change — `datafusion-bio-formats` (mirror in `bio-format-gff` and `bio-format-gtf`)
+
+**Branch base:** the rev currently pinned by polars-bio (`94d4d68…`), to isolate
+this feature from unrelated `master` changes.
+
+1. **Schema** (`table_provider.rs::determine_schema_on_demand`): in the Mode 2 loop
+   over `attr_fields`, if the name == `"attributes"`, push the nested
+   `List<Struct{tag,value}>` field (identical to the Mode 1 attributes field)
+   instead of a `Utf8` field. Field order follows `attr_fields` order.
+
+2. **Execution** (`physical_exec.rs`, both the local and the object-store streaming
+   functions):
+   - Partition `attr_fields` into `real_keys` (names ≠ `"attributes"`) and a flag
+     `include_nested = "attributes" ∈ attr_fields`.
+   - Keep flattened builders for `real_keys`. When `include_nested`, also populate
+     the nested builder per record (the same path Mode 1 uses).
+   - At batch assembly, build the output column vector by iterating `attr_fields`
+     in order: for `"attributes"` take the nested array, otherwise the matching
+     flattened array; prepend the static columns. Respect `projection` so
+     unrequested columns are still skipped.
+   - The `needs_attributes` short-circuit (skip parsing when only static columns
+     are requested) must remain true when `include_nested` or `real_keys` is
+     non-empty.
+
+3. Leave the existing either/or fast paths intact for the two unchanged modes.
+
+> Note: a latent `object_storage_options.unwrap()` in `get_local_gff` panics when
+> `None` is passed directly. The high-level polars-bio API never passes `None`, so
+> hardening it is **out of scope** here (noted for a future change).
+
+### polars-bio change
+
+**`polars_bio/io.py` — `AnnotationLazyFrameWrapper.select()`**: replace the
+`NotImplementedError` guard with a combined `_attr` request:
+
+```python
+needs_raw_attributes = "attributes" in scan_columns   # columns ∪ predicate roots
+if needs_raw_attributes and attr_cols:
+    _attr = attr_cols + ["attributes"]   # flattened fields + nested sentinel
+elif needs_raw_attributes:
+    _attr = None                          # pure nested (unchanged)
+elif attr_cols:
+    _attr = attr_cols                     # flattened only (unchanged)
+else:
+    _attr = []
+```
+
+`attr_cols` already excludes `"attributes"` (it is in `STATIC`), so no duplication.
+No other code in `select()` changes: once the registered table contains static +
+flattened + nested `attributes`, the existing predicate-pushdown/fallback and the
+final `.select(columns)` resolve every column by name and succeed.
+
+**`Cargo.toml`**: during development, point the ten `datafusion-bio-format-*`
+dependencies at the local clone path (`/Users/mwiewior/research/git/datafusion-bio-formats`)
+via `path = ...` to iterate without pushing. For the final commit, push the
+upstream feature branch and pin all ten deps to its commit SHA. Rebuild with
+`maturin develop --release`.
+
+## Testing (TDD)
+
+Tests are written before implementation in each repo and must fail first.
+
+### Upstream (`datafusion-bio-formats`) — Rust unit/integration tests
+- Schema: `attr_fields=["ID","attributes"]` yields columns `[...static, ID: Utf8,
+  attributes: List<Struct{tag,value}>]` in that order.
+- Execution: a small GFF and GTF fixture returns correct flattened `ID` **and**
+  fully-populated nested `attributes` for every row, including a row missing the
+  flattened key (→ null) while its nested `attributes` is still complete.
+- Unchanged-mode regression: `attr_fields=None` and `attr_fields=["ID"]` outputs
+  are byte-for-byte identical to the pinned-rev behavior.
+
+### polars-bio — pytest (extend `tests/test_filter_select_attributes_bug_fix.py`, `tests/test_io_gtf.py`)
+- **Rewrite** the two interim tests that assert `NotImplementedError` to assert
+  correct results instead.
+- Finding 1: `scan_gff().filter(pl.col("attributes").list.len() > N).select("ID")`
+  equals the `.collect()`-first oracle and has the expected rows.
+- Finding 2: `scan_gff(attr_fields=["ID"]).filter(pl.col("ID").str.contains(...))
+  .select("attributes")` returns the correct nested attributes for filtered rows.
+- Projection-only: `scan_gff().select(["attributes","ID"])` returns both columns
+  with correct values.
+- Issue #396 eager-vs-lazy equivalence: `lf.select(x).collect()` equals
+  `lf.collect().select(x)` for the mixed cases.
+- GTF equivalents of the above.
+- Oracle for parsed-field correctness: a derived field extracted from the nested
+  `attributes` via `list.eval(... struct.field ...)` equals the native flattened
+  column (already verified true for GFF and GTF during brainstorming).
+
+### Verification commands
+- Upstream: `cargo test -p datafusion-bio-format-gff -p datafusion-bio-format-gtf`
+- polars-bio: `maturin develop --release` then
+  `python -m pytest tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py tests/test_gff_eager_vs_lazy.py tests/test_optimization_bug_fix.py`
+
+## Risks & mitigations
+
+- **Two-repo coordination / pin ordering.** Mitigate with a local `path` override
+  for development; flip to a pushed commit SHA only for the final commit.
+- **Object-store streaming path divergence.** The remote variant must receive the
+  same dual-builder change as the local one; covered by an explicit checklist item
+  and (where feasible) a test.
+- **Column-order / projection mapping bugs.** Assemble output strictly in
+  `attr_fields` order and honor `projection`; covered by schema-order tests.
+- **Rebuild cost.** `maturin develop --release` against a changed Rust dep is slow;
+  expected, not avoidable.
+
+## Out of scope
+- Hardening the `object_storage_options.unwrap()` panic.
+- Changing the default (`attr_fields=None`) or pure-flattened behavior.
+- DataFusion-level predicate pushdown for nested `attributes` (`List<Struct>`)
+  predicates — these continue to evaluate client-side.

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2915,7 +2915,12 @@ def _lazy_scan(
 
             obj = _extract_py_object_storage_options(read_options)
 
-            if "attributes" in requested_cols:
+            # When both the raw nested ``attributes`` column and parsed fields
+            # are requested, use the reader's "attributes" sentinel to emit both
+            # from a single registration.
+            if "attributes" in requested_cols and attr_fields:
+                _attr = attr_fields + ["attributes"]
+            elif "attributes" in requested_cols:
                 _attr = None
             elif attr_fields:
                 _attr = attr_fields
@@ -3497,31 +3502,18 @@ class AnnotationLazyFrameWrapper:
 
             obj = _extract_py_object_storage_options(self._read_options)
 
-            # The GFF/GTF reader can materialize EITHER the raw ``attributes``
-            # column (attr_fields=None) OR a set of parsed attribute fields
-            # (attr_fields=[...]), but never both in a single registration.
-            # ``scan_columns`` (projection + deferred-predicate roots) may
-            # require both at once when a query mixes the raw ``attributes``
-            # column with parsed fields, e.g.
+            # ``scan_columns`` (projection + deferred-predicate roots) may need
+            # both the raw nested ``attributes`` column and parsed attribute
+            # fields at once, e.g.
             #   scan_gff(...).filter(pl.col("attributes")...).select("ID")
             #   scan_gff(..., attr_fields=["ID"]).filter(pl.col("ID")...).select("attributes")
-            # Such a combination cannot be satisfied here, so fail with an
-            # actionable message instead of a cryptic "No field named ..." error
-            # from the column projection further down.
+            # The reader supports the "attributes" sentinel: including it in
+            # ``attr_fields`` emits the nested ``attributes`` column alongside
+            # the flattened fields in a single registration.
             needs_raw_attributes = "attributes" in scan_columns
             if needs_raw_attributes and attr_cols:
-                raise NotImplementedError(
-                    "Combining the raw 'attributes' column with parsed "
-                    f"attribute field(s) {attr_cols} in a single "
-                    "filter()/select() is not supported: the GFF/GTF reader "
-                    "can expose either the raw 'attributes' column or parsed "
-                    "attribute fields, but not both at once. Work around this "
-                    "by collect()-ing before mixing them, or by handling the "
-                    "raw 'attributes' column and parsed fields in separate "
-                    "operations."
-                )
-
-            if needs_raw_attributes:
+                _attr = attr_cols + ["attributes"]
+            elif needs_raw_attributes:
                 _attr = None
             elif attr_cols:
                 _attr = attr_cols

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -3388,6 +3388,7 @@ class AnnotationLazyFrameWrapper:
             "view_prefix": "_pb_gtf_proj_",
         },
     }
+    _PRESERVE_DEFERRED_PREDICATE = object()
 
     def __init__(
         self,
@@ -3397,6 +3398,7 @@ class AnnotationLazyFrameWrapper:
         projection_pushdown: bool = True,
         predicate_pushdown: bool = True,
         format_type: str = "gff",
+        deferred_predicate: Optional[pl.Expr] = None,
     ):
         self._base_lf = base_lf
         self._file_path = file_path
@@ -3405,8 +3407,15 @@ class AnnotationLazyFrameWrapper:
         self._predicate_pushdown = predicate_pushdown
         self._format_type = format_type
         self._config = self._FORMAT_CONFIG[format_type]
+        self._deferred_predicate = deferred_predicate
 
-    def _make_wrapper(self, base_lf, projection_pushdown=None, predicate_pushdown=None):
+    def _make_wrapper(
+        self,
+        base_lf,
+        projection_pushdown=None,
+        predicate_pushdown=None,
+        deferred_predicate=_PRESERVE_DEFERRED_PREDICATE,
+    ):
         """Create a new wrapper of the same concrete type."""
         return type(self)(
             base_lf,
@@ -3421,6 +3430,11 @@ class AnnotationLazyFrameWrapper:
                 predicate_pushdown
                 if predicate_pushdown is not None
                 else self._predicate_pushdown
+            ),
+            (
+                self._deferred_predicate
+                if deferred_predicate is self._PRESERVE_DEFERRED_PREDICATE
+                else deferred_predicate
             ),
         )
 
@@ -3453,7 +3467,9 @@ class AnnotationLazyFrameWrapper:
             "phase",
             "attributes",
         }
-        attr_cols = [c for c in columns if c not in STATIC]
+        predicate_columns = self._extract_predicate_column_names()
+        scan_columns = list(dict.fromkeys(columns + predicate_columns))
+        attr_cols = [c for c in scan_columns if c not in STATIC]
 
         # If selecting attribute fields, run one-shot SQL projection with proper attr_fields
         if columns and (attr_cols or "attributes" in columns):
@@ -3461,11 +3477,7 @@ class AnnotationLazyFrameWrapper:
             from polars_bio.polars_bio import GtfReadOptions as _GtfReadOptions
             from polars_bio.polars_bio import InputFormat as _InputFormat
             from polars_bio.polars_bio import ReadOptions as _ReadOptions
-            from polars_bio.polars_bio import (
-                py_read_table,
-                py_register_table,
-                py_register_view,
-            )
+            from polars_bio.polars_bio import py_read_table, py_register_table
 
             from .context import ctx
 
@@ -3509,38 +3521,63 @@ class AnnotationLazyFrameWrapper:
 
             table = py_register_table(ctx, self._file_path, None, input_fmt, ropts)
 
-            # Extract WHERE clause from existing LazyFrame if it has filters applied
-            where_clause = ""
-            try:
-                logical_plan_str = str(self._base_lf.explain(optimized=False))
-                if "FILTER" in logical_plan_str:
-                    where_clause = self._extract_sql_where_clause(logical_plan_str)
-            except Exception:
-                pass
+            query_df = py_read_table(ctx, table.name)
+            datafusion_predicate_applied = False
+            if self._predicate_pushdown and self._deferred_predicate is not None:
+                try:
+                    from .predicate_translator import (
+                        datafusion_expr_to_sql,
+                        translate_predicate,
+                    )
 
-            import uuid
+                    _fmt_key = str(input_fmt).rsplit(".", 1)[-1]
+                    string_cols, uint32_cols, float32_cols = _FORMAT_COLUMN_TYPES.get(
+                        _fmt_key, (None, None, None)
+                    )
+                    df_expr = translate_predicate(
+                        self._deferred_predicate,
+                        string_cols,
+                        uint32_cols,
+                        float32_cols,
+                    )
+                    sql_predicate = datafusion_expr_to_sql(df_expr)
+                    native_expr = query_df.parse_sql_expr(sql_predicate)
+                    query_df = query_df.filter(native_expr)
+                    datafusion_predicate_applied = True
+                except Exception as e:
+                    logger.warning(
+                        f"DataFusion predicate pushdown failed, will filter "
+                        f"client-side (this may cause a full scan): {e}"
+                    )
 
-            select_clause = ", ".join([f'"{c}"' for c in columns])
-            view_name = f"{self._config['view_prefix']}{uuid.uuid4().hex}"
-            quoted_table = _quote_sql_identifier(table.name)
-            sql_query = f"SELECT {select_clause} FROM {quoted_table}"
-
-            if where_clause:
-                sql_query += f" WHERE {where_clause}"
-
-            py_register_view(ctx, view_name, sql_query)
-            df_view = py_read_table(ctx, view_name)
+            datafusion_columns = (
+                columns if datafusion_predicate_applied else scan_columns
+            )
+            if datafusion_columns:
+                select_exprs = [
+                    query_df.parse_sql_expr(f'"{c}"') for c in datafusion_columns
+                ]
+                query_df = query_df.select(*select_exprs)
 
             new_lf = _lazy_scan(
-                df_view,
+                query_df,
                 False,
-                self._predicate_pushdown,
-                view_name,
+                False,
+                table.name,
                 input_fmt,
                 self._file_path,
                 self._read_options,
             )
-            return self._make_wrapper(new_lf, projection_pushdown=False)
+            if (
+                self._deferred_predicate is not None
+                and not datafusion_predicate_applied
+            ):
+                new_lf = new_lf.filter(self._deferred_predicate)
+            if datafusion_columns != columns:
+                new_lf = new_lf.select(columns)
+            return self._make_wrapper(
+                new_lf, projection_pushdown=False, deferred_predicate=None
+            )
 
         # Otherwise delegate to Polars
         return self._make_wrapper(self._base_lf.select(exprs))
@@ -3551,7 +3588,22 @@ class AnnotationLazyFrameWrapper:
         pred = predicates[0]
         for p in predicates[1:]:
             pred = pred & p
-        return self._make_wrapper(self._base_lf.filter(pred))
+        deferred_predicate = (
+            pred
+            if self._deferred_predicate is None
+            else self._deferred_predicate & pred
+        )
+        return self._make_wrapper(
+            self._base_lf.filter(pred), deferred_predicate=deferred_predicate
+        )
+
+    def _extract_predicate_column_names(self):
+        if self._deferred_predicate is None:
+            return []
+        try:
+            return list(self._deferred_predicate.meta.root_names())
+        except Exception:
+            return []
 
     def _extract_sql_where_clause(self, logical_plan_str):
         """Extract SQL WHERE clause from Polars logical plan string."""
@@ -3646,6 +3698,7 @@ class GffLazyFrameWrapper(AnnotationLazyFrameWrapper):
         read_options,
         projection_pushdown=True,
         predicate_pushdown=True,
+        deferred_predicate=None,
     ):
         super().__init__(
             base_lf,
@@ -3654,6 +3707,7 @@ class GffLazyFrameWrapper(AnnotationLazyFrameWrapper):
             projection_pushdown,
             predicate_pushdown,
             "gff",
+            deferred_predicate,
         )
 
 
@@ -3665,6 +3719,7 @@ class GtfLazyFrameWrapper(AnnotationLazyFrameWrapper):
         read_options,
         projection_pushdown=True,
         predicate_pushdown=True,
+        deferred_predicate=None,
     ):
         super().__init__(
             base_lf,
@@ -3673,4 +3728,5 @@ class GtfLazyFrameWrapper(AnnotationLazyFrameWrapper):
             projection_pushdown,
             predicate_pushdown,
             "gtf",
+            deferred_predicate,
         )

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -3497,7 +3497,31 @@ class AnnotationLazyFrameWrapper:
 
             obj = _extract_py_object_storage_options(self._read_options)
 
-            if "attributes" in columns:
+            # The GFF/GTF reader can materialize EITHER the raw ``attributes``
+            # column (attr_fields=None) OR a set of parsed attribute fields
+            # (attr_fields=[...]), but never both in a single registration.
+            # ``scan_columns`` (projection + deferred-predicate roots) may
+            # require both at once when a query mixes the raw ``attributes``
+            # column with parsed fields, e.g.
+            #   scan_gff(...).filter(pl.col("attributes")...).select("ID")
+            #   scan_gff(..., attr_fields=["ID"]).filter(pl.col("ID")...).select("attributes")
+            # Such a combination cannot be satisfied here, so fail with an
+            # actionable message instead of a cryptic "No field named ..." error
+            # from the column projection further down.
+            needs_raw_attributes = "attributes" in scan_columns
+            if needs_raw_attributes and attr_cols:
+                raise NotImplementedError(
+                    "Combining the raw 'attributes' column with parsed "
+                    f"attribute field(s) {attr_cols} in a single "
+                    "filter()/select() is not supported: the GFF/GTF reader "
+                    "can expose either the raw 'attributes' column or parsed "
+                    "attribute fields, but not both at once. Work around this "
+                    "by collect()-ing before mixing them, or by handling the "
+                    "raw 'attributes' column and parsed fields in separate "
+                    "operations."
+                )
+
+            if needs_raw_attributes:
                 _attr = None
             elif attr_cols:
                 _attr = attr_cols
@@ -3604,87 +3628,6 @@ class AnnotationLazyFrameWrapper:
             return list(self._deferred_predicate.meta.root_names())
         except Exception:
             return []
-
-    def _extract_sql_where_clause(self, logical_plan_str):
-        """Extract SQL WHERE clause from Polars logical plan string."""
-        import re
-
-        selection_match = re.search(r"SELECTION:\s*(.+)", logical_plan_str)
-        if selection_match:
-            selection_expr = selection_match.group(1).strip()
-            try:
-                return _build_sql_where_from_predicate_safe(selection_expr)
-            except Exception:
-                pass
-
-        filter_lines = []
-        for line in logical_plan_str.split("\n"):
-            if "FILTER" in line and "[" in line:
-                filter_lines.append(line.strip())
-
-        if not filter_lines:
-            return ""
-
-        all_conditions = []
-        for line in filter_lines:
-            match = re.search(r"FILTER\s+\[(.+?)\]", line)
-            if match:
-                condition = match.group(1)
-                try:
-                    sql_condition = _build_sql_where_from_predicate_safe(condition)
-                    if sql_condition:
-                        all_conditions.append(sql_condition)
-                except Exception:
-                    continue
-
-        if all_conditions:
-            return " AND ".join(all_conditions)
-
-        return ""
-
-    def _parse_filter_expression(self, filter_expr):
-        """Parse filter expression string to SQL WHERE clause."""
-        import re
-
-        conditions = []
-
-        str_patterns = [
-            r'col\("([^"]+)"\)\.eq\(lit\("([^"]*)"\)\)',
-            r'col\("([^"]+)"\)\s*==\s*"([^"]*)"',
-        ]
-        for pat in str_patterns:
-            for column, value in re.findall(pat, filter_expr):
-                conditions.append(f"\"{column}\" = '{value}'")
-
-        numeric_patterns = [
-            (r'col\("([^"]+)"\)\.gt\(lit\((\d+)\)\)', ">"),
-            (r'col\("([^"]+)"\)\.lt\(lit\((\d+)\)\)', "<"),
-            (r'col\("([^"]+)"\)\.gt_eq\(lit\((\d+)\)\)', ">="),
-            (r'col\("([^"]+)"\)\.lt_eq\(lit\((\d+)\)\)', "<="),
-            (r'col\("([^"]+)"\)\.neq\(lit\((\d+)\)\)', "!="),
-            (r'col\("([^"]+)"\)\.eq\(lit\((\d+)\)\)', "="),
-            (r'col\("([^"]+)"\)\s*>\s*(\d+)', ">"),
-            (r'col\("([^"]+)"\)\s*<\s*(\d+)', "<"),
-            (r'col\("([^"]+)"\)\s*>=\s*(\d+)', ">="),
-            (r'col\("([^"]+)"\)\s*<=\s*(\d+)', "<="),
-            (r'col\("([^"]+)"\)\s*!=\s*(\d+)', "!="),
-            (r'col\("([^"]+)"\)\s*==\s*(\d+)', "="),
-        ]
-
-        for pattern, op in numeric_patterns:
-            matches = re.findall(pattern, filter_expr)
-            for column, value in matches:
-                conditions.append(f'"{column}" {op} {value}')
-
-        if conditions:
-            return " AND ".join(conditions)
-
-        try:
-            return _build_sql_where_from_predicate_safe(filter_expr)
-        except Exception:
-            pass
-
-        return ""
 
     def __getattr__(self, name):
         return getattr(self._base_lf, name)

--- a/tests/test_filter_select_attributes_bug_fix.py
+++ b/tests/test_filter_select_attributes_bug_fix.py
@@ -293,34 +293,82 @@ class TestFilterSelectAttributesBug:
         pl.testing.assert_frame_equal(projected, collected_first)
         assert projected.height == 0
 
-    def test_raw_attributes_predicate_with_parsed_select_raises(self, test_gff_file):
-        """Mixing a raw-``attributes`` predicate with a parsed-field select.
+    def test_raw_attributes_predicate_with_parsed_select(self, test_gff_file):
+        """Predicate on raw nested ``attributes`` + select a parsed field returns correct rows.
 
-        The GFF reader can expose either the raw ``attributes`` column or
-        parsed attribute fields, but not both in one registration, so this
-        combination must raise a clear ``NotImplementedError`` instead of a
-        cryptic DataFusion "No field named" schema error.
+        A single registration now exposes both the raw ``attributes`` column
+        and parsed attribute fields (via the reader's "attributes" sentinel),
+        so this no longer raises.
         """
-        lf = pb.scan_gff(test_gff_file).filter(
-            pl.col("attributes").str.contains("protein_coding")
+        # Select rows that carry a "Type" attribute (only gene rows do in the fixture).
+        has_type = (
+            pl.col("attributes")
+            .list.eval(pl.element().struct.field("tag"))
+            .list.contains("Type")
+        )
+        extract_id = (
+            pl.col("attributes")
+            .list.eval(
+                pl.element()
+                .filter(pl.element().struct.field("tag") == "ID")
+                .struct.field("value")
+            )
+            .list.first()
+            .alias("ID")
         )
 
-        with pytest.raises(NotImplementedError, match="raw 'attributes' column"):
-            lf.select("ID").collect()
-
-    def test_parsed_predicate_with_raw_attributes_select_raises(self, test_gff_file):
-        """Mixing a parsed-field predicate with a raw-``attributes`` select.
-
-        Symmetric to the previous case: the predicate needs the parsed ``ID``
-        field while the projection needs the raw ``attributes`` column, which
-        cannot be served by a single registration.
-        """
-        lf = pb.scan_gff(test_gff_file, attr_fields=["ID"]).filter(
-            pl.col("ID").str.contains("GENE")
+        projected = pb.scan_gff(test_gff_file).filter(has_type).select("ID").collect()
+        # Independent oracle: extract ID from the nested attributes via eager Polars.
+        oracle = (
+            pb.scan_gff(test_gff_file).filter(has_type).collect().select(extract_id)
         )
 
-        with pytest.raises(NotImplementedError, match="raw 'attributes' column"):
-            lf.select("attributes").collect()
+        pl.testing.assert_frame_equal(projected, oracle)
+        assert projected.height > 0
+        assert projected["ID"].null_count() == 0
+
+    def test_parsed_predicate_with_raw_attributes_select(self, test_gff_file):
+        """Predicate on a parsed field + select the raw nested ``attributes`` returns correct rows."""
+        flt = pl.col("ID").str.contains("GENE")
+        got = (
+            pb.scan_gff(test_gff_file, attr_fields=["ID"])
+            .filter(flt)
+            .select("attributes")
+            .collect()
+        )
+        expected_ids = (
+            pb.scan_gff(test_gff_file, attr_fields=["ID"])
+            .filter(flt)
+            .select("ID")
+            .collect()["ID"]
+            .to_list()
+        )
+
+        assert got.height == len(expected_ids)
+        assert got.height > 0
+        # Each returned nested attributes row contains its matching ID value.
+        recovered = got.select(
+            pl.col("attributes")
+            .list.eval(
+                pl.element()
+                .filter(pl.element().struct.field("tag") == "ID")
+                .struct.field("value")
+            )
+            .list.first()
+            .alias("ID")
+        )["ID"].to_list()
+        assert recovered == expected_ids
+
+    def test_select_raw_attributes_and_parsed_field_together(self, test_gff_file):
+        """Selecting raw ``attributes`` and a parsed field together (no predicate) works."""
+        out = pb.scan_gff(test_gff_file).select(["attributes", "ID"]).collect()
+        assert set(out.columns) == {"attributes", "ID"}
+        assert out.height > 0
+        assert out["ID"].null_count() == 0
+        # attributes is the nested List<Struct> representation
+        assert out.schema["attributes"] == pl.List(
+            pl.Struct({"tag": pl.String, "value": pl.String})
+        )
 
 
 class TestFilterSelectPerformance:

--- a/tests/test_filter_select_attributes_bug_fix.py
+++ b/tests/test_filter_select_attributes_bug_fix.py
@@ -293,6 +293,35 @@ class TestFilterSelectAttributesBug:
         pl.testing.assert_frame_equal(projected, collected_first)
         assert projected.height == 0
 
+    def test_raw_attributes_predicate_with_parsed_select_raises(self, test_gff_file):
+        """Mixing a raw-``attributes`` predicate with a parsed-field select.
+
+        The GFF reader can expose either the raw ``attributes`` column or
+        parsed attribute fields, but not both in one registration, so this
+        combination must raise a clear ``NotImplementedError`` instead of a
+        cryptic DataFusion "No field named" schema error.
+        """
+        lf = pb.scan_gff(test_gff_file).filter(
+            pl.col("attributes").str.contains("protein_coding")
+        )
+
+        with pytest.raises(NotImplementedError, match="raw 'attributes' column"):
+            lf.select("ID").collect()
+
+    def test_parsed_predicate_with_raw_attributes_select_raises(self, test_gff_file):
+        """Mixing a parsed-field predicate with a raw-``attributes`` select.
+
+        Symmetric to the previous case: the predicate needs the parsed ``ID``
+        field while the projection needs the raw ``attributes`` column, which
+        cannot be served by a single registration.
+        """
+        lf = pb.scan_gff(test_gff_file, attr_fields=["ID"]).filter(
+            pl.col("ID").str.contains("GENE")
+        )
+
+        with pytest.raises(NotImplementedError, match="raw 'attributes' column"):
+            lf.select("attributes").collect()
+
 
 class TestFilterSelectPerformance:
     """Performance-related tests for the filter().select() fix."""

--- a/tests/test_filter_select_attributes_bug_fix.py
+++ b/tests/test_filter_select_attributes_bug_fix.py
@@ -272,6 +272,27 @@ class TestFilterSelectAttributesBug:
         assert all(result["chrom"] == "chr1"), "All results should be from chr1"
         assert "attributes" in result.columns, "Should include attributes column"
 
+    def test_filter_with_unsupported_attribute_predicate_selects_attribute(
+        self, test_gff_file
+    ):
+        """Unsupported attribute predicates must not be dropped before attr selection."""
+        lf = (
+            pb.scan_gff(
+                test_gff_file,
+                attr_fields=["ID", "Type"],
+                predicate_pushdown=True,
+                projection_pushdown=True,
+            )
+            .filter(pl.col("type") == "transcript")
+            .filter(pl.col("Type").str.contains("pseudogene"))
+        )
+
+        projected = lf.select("ID").collect()
+        collected_first = lf.collect().select("ID")
+
+        pl.testing.assert_frame_equal(projected, collected_first)
+        assert projected.height == 0
+
 
 class TestFilterSelectPerformance:
     """Performance-related tests for the filter().select() fix."""

--- a/tests/test_io_gtf.py
+++ b/tests/test_io_gtf.py
@@ -247,3 +247,30 @@ class TestIOGTF:
                 shutil.copyfileobj(f_in, f_out)
         df = pb.read_gtf(str(gz_path), compression_type="gz")
         assert len(df) == 23
+
+
+def test_gtf_parsed_predicate_with_raw_attributes_select(tmp_path):
+    """GTF: predicate on a parsed field + select the raw nested ``attributes``."""
+    gtf = tmp_path / "t.gtf"
+    gtf.write_text(
+        'chr1\ttest\tgene\t1\t9\t.\t+\t.\tgene_id "ENSG1"; gene_name "A";\n'
+        'chr1\ttest\tgene\t10\t19\t.\t+\t.\tgene_id "ENSG2"; gene_name "B";\n'
+    )
+    got = (
+        pb.scan_gtf(str(gtf), attr_fields=["gene_id"])
+        .filter(pl.col("gene_id") == "ENSG1")
+        .select("attributes")
+        .collect()
+    )
+    assert got.height == 1
+    recovered = got.select(
+        pl.col("attributes")
+        .list.eval(
+            pl.element()
+            .filter(pl.element().struct.field("tag") == "gene_id")
+            .struct.field("value")
+        )
+        .list.first()
+        .alias("gene_id")
+    )["gene_id"].to_list()
+    assert recovered == ["ENSG1"]

--- a/tests/test_io_gtf.py
+++ b/tests/test_io_gtf.py
@@ -219,6 +219,25 @@ class TestIOGTF:
         assert df["tag"][0] == "basic,TAGENE,appris_principal_3,CCDS"
         assert df["gene_name"][0] == "GAPDH"
 
+    def test_filter_with_unsupported_attribute_predicate_selects_attribute(self):
+        """Unsupported attribute predicates must not be dropped before attr selection."""
+        lf = (
+            pb.scan_gtf(
+                GTF_PATH,
+                attr_fields=["gene_type", "transcript_id"],
+                predicate_pushdown=True,
+                projection_pushdown=True,
+            )
+            .filter(pl.col("type") == "transcript")
+            .filter(pl.col("gene_type").str.contains("pseudogene"))
+        )
+
+        projected = lf.select("transcript_id").collect()
+        collected_first = lf.collect().select("transcript_id")
+
+        pl.testing.assert_frame_equal(projected, collected_first)
+        assert projected.height == 0
+
     def test_compression_type_override(self, tmp_path):
         """Explicit compression_type overrides auto-detection."""
         # Create a gzip file with .gtf.gz extension but read with explicit compression_type


### PR DESCRIPTION
## Summary
- Preserve the original GFF/GTF Polars predicate in the annotation LazyFrame wrapper instead of reconstructing partial SQL from `explain()` output.
- Include predicate root columns when re-registering attribute projections, so unsupported predicates can be evaluated client-side without losing needed columns.
- Add regression coverage for both `scan_gff()` and `scan_gtf()` when an unsupported attribute predicate is followed by selecting an attribute column.

Fixes #396

## Verification
- `uv run pytest tests/test_filter_select_attributes_bug_fix.py tests/test_io_gtf.py tests/test_gff_eager_vs_lazy.py tests/test_optimization_bug_fix.py`
- `git diff --check`