### PR TITLE
fix: Normalize FASTQ columns before writing

### DIFF
--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2463,6 +2463,32 @@ def _cleanse_fields(t: Union[list[str], None]) -> Union[list[str], None]:
     return [x.strip() for x in t]
 
 
+_FASTQ_COLUMNS = ["name", "description", "sequence", "quality_scores"]
+_FASTQ_REQUIRED_COLUMNS = ["name", "sequence", "quality_scores"]
+
+
+def _normalize_fastq_columns(
+    df: Union[pl.DataFrame, pl.LazyFrame],
+) -> Union[pl.DataFrame, pl.LazyFrame]:
+    columns = (
+        df.collect_schema().names() if isinstance(df, pl.LazyFrame) else df.columns
+    )
+    missing = [column for column in _FASTQ_REQUIRED_COLUMNS if column not in columns]
+    if missing:
+        raise ValueError(
+            "FASTQ write requires columns: "
+            + ", ".join(_FASTQ_REQUIRED_COLUMNS)
+            + f"; missing: {', '.join(missing)}"
+        )
+
+    if "description" in columns:
+        df = df.with_columns(pl.col("description").cast(pl.String))
+    else:
+        df = df.with_columns(pl.lit(None, dtype=pl.String).alias("description"))
+
+    return df.select(_FASTQ_COLUMNS)
+
+
 def _write_file(
     df: Union[pl.DataFrame, pl.LazyFrame],
     path: str,
@@ -2541,6 +2567,7 @@ def _write_file(
     elif output_format == OutputFormat.Fastq:
         fastq_opts = FastqWriteOptions()
         write_options = WriteOptions(fastq_write_options=fastq_opts)
+        df = _normalize_fastq_columns(df)
     else:
         write_options = None
 

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2506,7 +2506,7 @@ def _write_file(
     Parameters:
         df: The DataFrame or LazyFrame to write.
         path: The output file path.
-        output_format: The output format (Vcf or Fastq).
+        output_format: The output format.
 
     Returns:
         The number of rows written.

--- a/tests/test_fastq_write.py
+++ b/tests/test_fastq_write.py
@@ -44,6 +44,47 @@ class TestFastqWriteBasic:
         df2 = pb.read_fastq(str(output_path))
         assert len(df2) == len(df)
 
+    def test_write_fastq_documented_column_order(self, tmp_path):
+        """Test writing FASTQ data with columns ordered as documented."""
+        output_path = tmp_path / "documented_order.fastq"
+        sequence = "ACGT" * 37
+        quality_scores = "I" * len(sequence)
+        df = pl.DataFrame(
+            {
+                "name": ["read1"],
+                "sequence": [sequence],
+                "quality_scores": [quality_scores],
+            }
+        ).with_columns(pl.lit(None).alias("description"))
+
+        row_count = pb.write_fastq(df, str(output_path))
+
+        assert row_count == 1
+        df2 = pb.read_fastq(str(output_path))
+        assert df2["sequence"].to_list() == [sequence]
+        assert df2["quality_scores"].to_list() == [quality_scores]
+
+    def test_write_fastq_without_description(self, tmp_path):
+        """Test writing FASTQ data without the optional description column."""
+        output_path = tmp_path / "without_description.fastq"
+        sequence = "ACGT"
+        quality_scores = "IIII"
+        df = pl.DataFrame(
+            {
+                "name": ["read1"],
+                "sequence": [sequence],
+                "quality_scores": [quality_scores],
+            }
+        )
+
+        row_count = pb.write_fastq(df, str(output_path))
+
+        assert row_count == 1
+        df2 = pb.read_fastq(str(output_path))
+        assert df2["description"].to_list() == [None]
+        assert df2["sequence"].to_list() == [sequence]
+        assert df2["quality_scores"].to_list() == [quality_scores]
+
     def test_write_auto_compression_detection(self, tmp_path):
         """Test that compression is auto-detected from extension."""
         input_path = f"{DATA_DIR}/io/fastq/example.fastq"
@@ -170,6 +211,25 @@ class TestFastqSink:
         assert output_path.exists()
         df = pb.read_fastq(str(output_path))
         assert len(df) == 10
+
+    def test_sink_fastq_documented_column_order(self, tmp_path):
+        """Test streaming FASTQ data with columns ordered as documented."""
+        output_path = tmp_path / "sink_documented_order.fastq"
+        sequence = "ACGT" * 37
+        quality_scores = "I" * len(sequence)
+        df = pl.DataFrame(
+            {
+                "name": ["read1"],
+                "sequence": [sequence],
+                "quality_scores": [quality_scores],
+            }
+        ).with_columns(pl.lit(None).alias("description"))
+
+        pb.sink_fastq(df.lazy(), str(output_path))
+
+        df2 = pb.read_fastq(str(output_path))
+        assert df2["sequence"].to_list() == [sequence]
+        assert df2["quality_scores"].to_list() == [quality_scores]
 
 
 class TestFastqFromCompressed:

--- a/tests/test_fastq_write.py
+++ b/tests/test_fastq_write.py
@@ -85,6 +85,28 @@ class TestFastqWriteBasic:
         assert df2["sequence"].to_list() == [sequence]
         assert df2["quality_scores"].to_list() == [quality_scores]
 
+    def test_write_fastq_shuffled_columns(self, tmp_path):
+        """Test writing FASTQ data when columns are not in writer order."""
+        output_path = tmp_path / "shuffled.fastq"
+        sequence = "ACGT"
+        quality_scores = "IIII"
+        df = pl.DataFrame(
+            {
+                "quality_scores": [quality_scores],
+                "sequence": [sequence],
+                "name": ["read1"],
+            }
+        )
+
+        row_count = pb.write_fastq(df, str(output_path))
+
+        assert row_count == 1
+        df2 = pb.read_fastq(str(output_path))
+        assert df2["name"].to_list() == ["read1"]
+        assert df2["description"].to_list() == [None]
+        assert df2["sequence"].to_list() == [sequence]
+        assert df2["quality_scores"].to_list() == [quality_scores]
+
     def test_write_auto_compression_detection(self, tmp_path):
         """Test that compression is auto-detected from extension."""
         input_path = f"{DATA_DIR}/io/fastq/example.fastq"
@@ -228,6 +250,29 @@ class TestFastqSink:
         pb.sink_fastq(df.lazy(), str(output_path))
 
         df2 = pb.read_fastq(str(output_path))
+        assert df2["sequence"].to_list() == [sequence]
+        assert df2["quality_scores"].to_list() == [quality_scores]
+
+    def test_sink_fastq_from_parquet_shuffled_columns(self, tmp_path):
+        """Test streaming FASTQ data from parquet with columns in source order."""
+        parquet_path = tmp_path / "shuffled.parquet"
+        output_path = tmp_path / "sink_shuffled.fastq"
+        sequence = "ACGT"
+        quality_scores = "IIII"
+        df = pl.DataFrame(
+            {
+                "quality_scores": [quality_scores],
+                "sequence": [sequence],
+                "name": ["read1"],
+            }
+        )
+        df.write_parquet(parquet_path)
+
+        pb.sink_fastq(pl.scan_parquet(parquet_path), str(output_path))
+
+        df2 = pb.read_fastq(str(output_path))
+        assert df2["name"].to_list() == ["read1"]
+        assert df2["description"].to_list() == [None]
         assert df2["sequence"].to_list() == [sequence]
         assert df2["quality_scores"].to_list() == [quality_scores]
 


### PR DESCRIPTION
## Summary
- normalize FASTQ write inputs to the provider's expected column order: name, description, sequence, quality_scores
- cast or add the optional description column so None/missing descriptions remain writable
- add regression coverage for write_fastq and sink_fastq with documented column order

## Testing
- uv run pytest tests/test_fastq_write.py tests/test_io_fastq.py -q
- manual parquet LazyFrame sink_fastq reproduction from #400

Fixes #400

AI assistance was used under my direction.