### PR TITLE
ci: fix Claude review on fork PRs + harden workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Auto-review only runs for PRs from the same repository. Pull requests from
+    # forks do not receive repository secrets or an OIDC token, so the action
+    # cannot authenticate (CLAUDE_CODE_OAUTH_TOKEN is empty and `id-token` cannot
+    # be elevated). Fork PRs are instead reviewed on demand via `claude.yml`
+    # by commenting `@claude review this PR`.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,57 @@
+name: Claude Code
+
+# On-demand Claude invocation. Triggered by mentioning `@claude` in a comment.
+# These events (issue_comment / pull_request_review*) always run from the
+# default branch with repository secrets and an OIDC token available, even when
+# the pull request comes from a fork — so this is how fork PRs get reviewed.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only run when `@claude` is mentioned AND the author is a maintainer.
+    # The author_association gate prevents arbitrary external users from
+    # spending the OAuth token or using the comment body as an injection vector.
+    if: |
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      ) &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR'
+      )
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,14 +41,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 # v1.0.158
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'


### PR DESCRIPTION
## Problem

The **Claude Code Review** check fails on PRs from forks (e.g. #401) with a misleading error:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`id-token: write` is already present. The real cause: `pull_request` events from forks receive **no repository secrets and no OIDC token** (the permission cannot be elevated for fork PRs), so the action has no credentials — `CLAUDE_CODE_OAUTH_TOKEN` is empty and the OIDC fallback fails.

## Changes

1. **`claude-code-review.yml`** — guard the auto-review job to same-repo PRs (`head.repo.full_name == github.repository`) so fork PRs no longer produce a misleading red X. Fork PRs can't use this trigger anyway (no secrets).

2. **`claude.yml`** (new) — on-demand review triggered by `@claude` in a comment, gated to maintainers (`OWNER`/`MEMBER`/`COLLABORATOR`). `issue_comment` / `pull_request_review*` events run from the default branch **with** secrets + OIDC, so this works on fork PRs. Hardened with read-only `GITHUB_TOKEN` and `persist-credentials: false`.

3. **SHA-pinning** — both workflows pin `anthropics/claude-code-action` (v1.0.158) and `actions/checkout` (v5.0.1) to commit SHAs so a retagged/compromised action can't run with repository secrets.

## Notes / limitations

- These take effect once merged to `master`; the on-demand workflow only activates from the default branch.
- This does **not** retroactively clear #401's existing red X (that run uses the fork's own workflow file). After merge, a maintainer can comment `@claude review this PR` on #401 to review it.
- Residual risk: the on-demand path processes untrusted fork content while the OAuth token is in the environment (prompt-injection exposure). Consider restricting tools via `claude_args: '--allowedTools "Read,Grep,Glob"'` and/or scoping the Claude GitHub App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)