### PR TITLE
fix: remove unsupported parallel kwarg from register_fastq (#409)

### DIFF
--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -294,7 +294,6 @@ class SQL:
         timeout: int = 300,
         enable_request_payer: bool = False,
         compression_type: str = "auto",
-        parallel: bool = False,
     ) -> None:
         """
         Register a FASTQ file as a Datafusion table.
@@ -309,7 +308,6 @@ class SQL:
             compression_type: The compression type of the FASTQ file. If not specified, it will be detected automatically based on the file extension. BGZF and GZIP compression is supported ('bgz' and 'gz').
             max_retries:  The maximum number of retries for reading the file from object storage.
             timeout: The timeout in seconds for reading the file from object storage.
-            parallel: Whether to use the parallel reader for BGZF compressed files. Default is False. If a file ends with ".gz" but is actually BGZF, it will attempt the parallel path and fall back to standard if not BGZF.
 
         !!! Example
             ```python
@@ -351,7 +349,7 @@ class SQL:
         )
 
         fastq_read_options = FastqReadOptions(
-            object_storage_options=object_storage_options, parallel=parallel
+            object_storage_options=object_storage_options,
         )
         read_options = ReadOptions(fastq_read_options=fastq_read_options)
         py_register_table(ctx, path, name, InputFormat.Fastq, read_options)

--- a/tests/test_io_fastq.py
+++ b/tests/test_io_fastq.py
@@ -36,6 +36,12 @@ class TestFastq:
             == 200
         )
 
+    def test_register_fastq(self):
+        # Regression for #409: register_fastq must not pass an unsupported
+        # `parallel` kwarg to the FastqReadOptions binding.
+        pb.register_fastq(f"{DATA_DIR}/io/fastq/example.fastq.gz", "fq_409")
+        assert pb.sql("SELECT count(name) AS c FROM fq_409").collect()["c"][0] == 200
+
     def test_compression_override(self):
         assert (
             pb.scan_fastq(


### PR DESCRIPTION
## Summary
Fixes #409. `pb.register_fastq()` always crashed with:

```
TypeError: FastqReadOptions.__new__() got an unexpected keyword argument 'parallel'
```

## Root cause
PR #287 ("Unified FastqTableProvider with auto parallel reads") removed the `parallel` field from the `FastqReadOptions` PyO3 binding because parallel BGZF reads are now auto-detected at the Rust level. The lazy `read_fastq()` path in `io.py` was updated to match, but the SQL `register_fastq()` path in `sql.py` was missed and kept passing `parallel=parallel`, so every call crashed.

## Fix
- Remove the `parallel` parameter from `register_fastq()`'s signature.
- Remove the `parallel=parallel` kwarg from the `FastqReadOptions(...)` construction.
- Remove the now-inaccurate `parallel` docstring entry.
- Add `TestFastq::test_register_fastq` regression test (fails before, passes after).

No functionality is lost — parallel reading is now automatic.

## Testing
`python -m pytest tests/test_io_fastq.py -v` — all 10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)