### PR TITLE
fix :SELECT count(*) on a FASTQ table registered via register_fastq()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,8 +1465,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1491,8 +1491,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bbi"
-version = "1.6.3"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.6.4"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1503,8 +1503,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1526,8 +1526,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1548,8 +1548,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1574,8 +1574,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1597,8 +1597,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1621,8 +1621,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1649,8 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1674,8 +1674,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1702,8 +1702,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.8.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.4#46bc653ce06b2796138b6864c6eeff83131d60ed"
+version = "1.8.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,17 +28,17 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.4" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0", default-features = false }

--- a/tests/test_io_fastq.py
+++ b/tests/test_io_fastq.py
@@ -42,6 +42,14 @@ class TestFastq:
         pb.register_fastq(f"{DATA_DIR}/io/fastq/example.fastq.gz", "fq_409")
         assert pb.sql("SELECT count(name) AS c FROM fq_409").collect()["c"][0] == 200
 
+    def test_register_fastq_count_star(self):
+        # Regression for #411: SELECT count(*) is an empty-projection query.
+        # On a plain-gzip FASTQ (Sequential strategy) this previously failed with
+        # an Arrow schema mismatch ("columns(0) must match fields(1)"). Distinct
+        # from #409's count(name), which does not hit the empty-projection path.
+        pb.register_fastq(f"{DATA_DIR}/io/fastq/example.fastq.gz", "fq_411")
+        assert pb.sql("SELECT count(*) AS c FROM fq_411").collect()["c"][0] == 200
+
     def test_compression_override(self):
         assert (
             pb.scan_fastq(


### PR DESCRIPTION
## Summary

Bumps all 11 `datafusion-bio-format-*` git dependencies from tag **v1.8.4 → v1.8.5**.

This pulls in the upstream `COUNT(*)` / empty-projection fix ([biodatageeks/datafusion-bio-formats#208](https://github.com/biodatageeks/datafusion-bio-formats/pull/208)), which resolves **#411**: `SELECT count(*)` on a FASTQ table registered via `register_fastq()` failed with:

```
DataFusion error: Arrow error: Invalid argument error:
number of columns(0) must match number of fields(1) in schema
```

An audit of all format providers during that fix found the **PAIRS** provider had the same class of bug (mirror direction), also fixed in v1.8.5. The other formats (VCF/BAM/CRAM/GFF/GTF/BED/FASTA/BigWig/BigBed) were already correct.

## Changes
- `Cargo.toml`: 11 dependency tags `v1.8.4` → `v1.8.5`
- `Cargo.lock`: regenerated for the bumped git sources

## Verification
- `cargo check` passes locally against v1.8.5.

Closes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)