### PR TITLE
feat: add register_fasta + refresh docs/changelog since 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- BigWig and BigBed I/O APIs (#393)
+  - `read_bigwig()`, `scan_bigwig()`, `register_bigwig()` and
+    `read_bigbed()`, `scan_bigbed()`, `register_bigbed()`
+  - Local and cloud storage input, eager/lazy/register access patterns
+- VCF Zarr `describe` and registration APIs (#391)
+  - `describe_vcf_zarr()` to introspect the logical VCF schema of a store
+  - `register_vcf_zarr()` to register a VCF Zarr store as a DataFusion table
+- `register_fasta()` to register a FASTA file as a DataFusion table, completing
+  the eager/lazy/register triad for FASTA
+
+### Changed
+- Robust predicate & projection pushdown across formats (#407, fixes #396)
+- Bumped the DataFusion stack to 53 and raised the pyarrow floor (#392)
+
 ### Fixed
 - `scan_fastq` / `read_fastq` now read **all** members of multi-member
   (concatenated / block) gzip files (pigz, bgzip-as-gzip, fastp output).
   Previously only the first gzip member was decoded, which silently dropped
   reads or raised `DataFusion error: External(Kind(UnexpectedEof))` depending
   on where the member boundary fell. Fixed via the upstream
-  datafusion-bio-formats bump.
+  datafusion-bio-formats bump (#408)
+- `SELECT count(*)` on a FASTQ table registered via `register_fastq()` (#412)
+- Removed the unsupported `parallel` kwarg from `register_fastq` (#409, #410)
+- Normalize FASTQ columns before writing (#401)
+- Consume the upstream bare VCF INFO key parser fix (#389)
+
+## [0.31.0] - 2026-05-13
+
+### Added
+- VCF Zarr read support (#382)
+  - `read_vcf_zarr()` and `scan_vcf_zarr()` for array-native variant analytics
+  - Lazy scans, eager reads, projection pushdown, INFO/FORMAT field selection,
+    sample selection, raw typed genotype values, and genomic predicate pruning
+    via the VCZ region index
+  - Backed by a new `datafusion-bio-formats` VCF Zarr provider using the Rust
+    `zarrs` crate
+
+## [0.30.0] - 2026-04-29
+
+### Added
+- Overlap `left` output mode (#377)
+
+### Changed
+- Optimized range operations (#378)
+
+## [0.29.0] - 2026-04-24
+
+### Changed
+- Improved eager partitioning (#374)
+
+### Fixed
+- Parallelize LazyFrame Arrow C stream inputs (#371)
+
+## [0.28.0] - 2026-04-09
+
+### Added
+- Typed BAM/SAM tag roundtrip support (#366)
+
+## [0.27.1] - 2026-04-05
+
+### Fixed
+- GTF `attr_fields` now returns all values for duplicate keys (#358, #359)
+- BAM/CRAM write position off-by-one (#356, #357)
+
+## [0.27.0] - 2026-04-03
+
+### Added
+- FASTA write and sink support (#353)
+  - `write_fasta()` and `sink_fasta()`
+
+### Fixed
+- Handle INFO/FORMAT column name collision in single-sample VCFs (#354)
 
 ## [0.26.0] - 2026-03-07
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -587,6 +587,7 @@ For bioinformatic format there are always three methods available: `read_*` (eag
 |--------------------------------------------------|--------------------|--------------------|--------------------|--------------------|---------------------|
 | [BED](api.md#polars_bio.data_input.read_bed)     | :white_check_mark: | ❌                  | :white_check_mark: | ❌                  | ❌                   |
 | [VCF](api.md#polars_bio.data_input.read_vcf)     | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| [VCF Zarr](api.md#polars_bio.data_input.read_vcf_zarr) | :white_check_mark: | :white_check_mark: (region index) | ❌ | :white_check_mark: | :white_check_mark: |
 | [BAM](api.md#polars_bio.data_input.read_bam)     | :white_check_mark: | :white_check_mark: (BAI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [CRAM](api.md#polars_bio.data_input.read_cram)   | :white_check_mark: | :white_check_mark: (CRAI) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [FASTQ](api.md#polars_bio.data_input.read_fastq) | :white_check_mark: | :white_check_mark: (GZI) | :white_check_mark: |  ❌  |  ❌   |
@@ -594,6 +595,35 @@ For bioinformatic format there are always three methods available: `read_*` (eag
 | [GFF3](api.md#polars_bio.data_input.read_gff)    | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [GTF](api.md#polars_bio.data_input.read_gtf)     | :white_check_mark: | ❌                  | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [Pairs](api.md#polars_bio.data_input.read_pairs) | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
+| [BigWig](api.md#polars_bio.data_input.read_bigwig) | :white_check_mark: | ❌ | ❌ | :white_check_mark: | :white_check_mark: |
+| [BigBed](api.md#polars_bio.data_input.read_bigbed) | :white_check_mark: | ❌ | ❌ | :white_check_mark: | :white_check_mark: |
+
+
+### BigWig and BigBed
+
+[BigWig](https://genome.ucsc.edu/goldenPath/help/bigWig.html) (continuous signal) and
+[BigBed](https://genome.ucsc.edu/goldenPath/help/bigBed.html) (feature intervals) are
+supported through the same eager/lazy/register access patterns. Predicate pushdown on the
+genomic coordinate columns and projection pushdown are enabled by default.
+
+```python
+import polars as pl
+import polars_bio as pb
+
+# Lazy scan with a genomic range filter (predicate pushdown)
+signal = (
+    pb.scan_bigwig("signal.bw")
+    .filter(pl.col("chrom") == "chr1")
+    .collect()
+)
+
+# Eager read
+features = pb.read_bigbed("features.bb")
+
+# Register as a DataFusion table for SQL
+pb.register_bigwig("signal.bw", "signal")
+pb.sql("SELECT chrom, start, `end`, value FROM signal WHERE chrom = 'chr1'").collect()
+```
 
 
 ### Indexed reads & predicate pushdown

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -50,6 +50,7 @@ register_gtf = data_processing.register_gtf
 register_vcf = data_processing.register_vcf
 register_vcf_zarr = data_processing.register_vcf_zarr
 register_fastq = data_processing.register_fastq
+register_fasta = data_processing.register_fasta
 register_bam = data_processing.register_bam
 register_sam = data_processing.register_sam
 register_cram = data_processing.register_cram
@@ -204,6 +205,7 @@ __all__ = [
     "register_vcf",
     "register_vcf_zarr",
     "register_fastq",
+    "register_fasta",
     "register_bam",
     "register_sam",
     "register_cram",

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -401,6 +401,7 @@ class IOOperations:
             projection_pushdown: Enable column projection pushdown to optimize query performance by only reading the necessary columns at the DataFusion level.
             predicate_pushdown: Enable predicate pushdown using index files (TBI/CSI) for efficient region-based filtering. Index files are auto-discovered (e.g., `file.vcf.gz.tbi`). Only simple predicates are pushed down (equality, comparisons, IN); complex predicates like `.str.contains()` or OR logic are filtered client-side. Correctness is always guaranteed.
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration `datafusion.bio.coordinate_system_zero_based`.
+            genotype_encoding_raw: If True, output GT as raw typed allele calls. If False, output VCF-style GT strings.
 
         !!! note
             By default, coordinates are output in **1-based closed** format. Use `use_zero_based=True` or set `pb.set_option(pb.POLARS_BIO_COORDINATE_SYSTEM_ZERO_BASED, True)` for 0-based half-open coordinates.
@@ -1833,6 +1834,19 @@ class IOOperations:
         Read a BigWig file into a DataFrame.
 
         BigWig rows are exposed as ``chrom``, ``start``, ``end``, and ``value``.
+
+        Parameters:
+            path: The path to the BigWig file.
+            chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
+            concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
+            allow_anonymous: [GCS, AWS S3] Whether to allow anonymous access to object storage.
+            enable_request_payer: [AWS S3] Whether to enable request payer for object storage. This is useful for reading files from AWS S3 buckets that require request payer.
+            max_retries: The maximum number of retries for reading the file from object storage.
+            timeout: The timeout in seconds for reading the file from object storage.
+            compression_type: The compression type of the BigWig file. If not specified, it will be detected automatically based on the file extension.
+            projection_pushdown: Enable column projection pushdown optimization. When True, only requested columns are processed at the DataFusion execution level, improving performance and reducing memory usage.
+            predicate_pushdown: Enable predicate pushdown on the genomic coordinate columns so range filters are evaluated at the DataFusion execution level.
+            use_zero_based: Coordinate system override. BigWig is natively 0-based half-open; set to *False* to emit 1-based closed coordinates, or *None* to use the global default.
         """
         lf = IOOperations.scan_bigwig(
             path,
@@ -1872,6 +1886,19 @@ class IOOperations:
 
         BigWig is natively 0-based half-open. Set ``use_zero_based=False`` to emit
         1-based closed coordinates.
+
+        Parameters:
+            path: The path to the BigWig file.
+            chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
+            concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
+            allow_anonymous: [GCS, AWS S3] Whether to allow anonymous access to object storage.
+            enable_request_payer: [AWS S3] Whether to enable request payer for object storage. This is useful for reading files from AWS S3 buckets that require request payer.
+            max_retries: The maximum number of retries for reading the file from object storage.
+            timeout: The timeout in seconds for reading the file from object storage.
+            compression_type: The compression type of the BigWig file. If not specified, it will be detected automatically based on the file extension.
+            projection_pushdown: Enable column projection pushdown optimization. When True, only requested columns are processed at the DataFusion execution level, improving performance and reducing memory usage.
+            predicate_pushdown: Enable predicate pushdown on the genomic coordinate columns so range filters are evaluated at the DataFusion execution level.
+            use_zero_based: Coordinate system override. BigWig is natively 0-based half-open; set to *False* to emit 1-based closed coordinates, or *None* to use the global default.
         """
         object_storage_options = PyObjectStorageOptions(
             allow_anonymous=allow_anonymous,
@@ -1918,6 +1945,20 @@ class IOOperations:
 
         ``schema="auto"`` uses supported autoSQL fields when available.
         ``schema="rest"`` exposes the raw trailing fields in ``rest``.
+
+        Parameters:
+            path: The path to the BigBed file.
+            chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
+            concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
+            allow_anonymous: [GCS, AWS S3] Whether to allow anonymous access to object storage.
+            enable_request_payer: [AWS S3] Whether to enable request payer for object storage. This is useful for reading files from AWS S3 buckets that require request payer.
+            max_retries: The maximum number of retries for reading the file from object storage.
+            timeout: The timeout in seconds for reading the file from object storage.
+            compression_type: The compression type of the BigBed file. If not specified, it will be detected automatically based on the file extension.
+            projection_pushdown: Enable column projection pushdown optimization. When True, only requested columns are processed at the DataFusion execution level, improving performance and reducing memory usage.
+            predicate_pushdown: Enable predicate pushdown on the genomic coordinate columns so range filters are evaluated at the DataFusion execution level.
+            use_zero_based: Coordinate system override. BigBed is natively 0-based half-open; set to *False* to emit 1-based closed coordinates, or *None* to use the global default.
+            schema: Schema mode. ``"auto"`` exposes the supported autoSQL fields when available; ``"rest"`` exposes the raw trailing fields in a single ``rest`` column.
         """
         lf = IOOperations.scan_bigbed(
             path,
@@ -1959,6 +2000,20 @@ class IOOperations:
 
         BigBed is natively 0-based half-open. Set ``use_zero_based=False`` to emit
         1-based closed coordinates.
+
+        Parameters:
+            path: The path to the BigBed file.
+            chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
+            concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
+            allow_anonymous: [GCS, AWS S3] Whether to allow anonymous access to object storage.
+            enable_request_payer: [AWS S3] Whether to enable request payer for object storage. This is useful for reading files from AWS S3 buckets that require request payer.
+            max_retries: The maximum number of retries for reading the file from object storage.
+            timeout: The timeout in seconds for reading the file from object storage.
+            compression_type: The compression type of the BigBed file. If not specified, it will be detected automatically based on the file extension.
+            projection_pushdown: Enable column projection pushdown optimization. When True, only requested columns are processed at the DataFusion execution level, improving performance and reducing memory usage.
+            predicate_pushdown: Enable predicate pushdown on the genomic coordinate columns so range filters are evaluated at the DataFusion execution level.
+            use_zero_based: Coordinate system override. BigBed is natively 0-based half-open; set to *False* to emit 1-based closed coordinates, or *None* to use the global default.
+            schema: Schema mode. ``"auto"`` exposes the supported autoSQL fields when available; ``"rest"`` exposes the raw trailing fields in a single ``rest`` column.
         """
         object_storage_options = PyObjectStorageOptions(
             allow_anonymous=allow_anonymous,

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -8,6 +8,7 @@ from polars_bio.polars_bio import (
     BigBedReadOptions,
     BigWigReadOptions,
     CramReadOptions,
+    FastaReadOptions,
     FastqReadOptions,
     GffReadOptions,
     GtfReadOptions,
@@ -437,6 +438,60 @@ class SQL:
         )
         read_options = ReadOptions(bed_read_options=bed_read_options)
         py_register_table(ctx, path, name, InputFormat.Bed, read_options)
+
+    @staticmethod
+    def register_fasta(
+        path: str,
+        name: Union[str, None] = None,
+        chunk_size: int = 8,
+        concurrent_fetches: int = 1,
+        allow_anonymous: bool = True,
+        max_retries: int = 5,
+        timeout: int = 300,
+        enable_request_payer: bool = False,
+        compression_type: str = "auto",
+    ) -> None:
+        """
+        Register a FASTA file as a Datafusion table.
+
+        Parameters:
+            path: The path to the FASTA file.
+            name: The name of the table. If *None*, the name of the table will be generated automatically based on the path.
+            chunk_size: The size in MB of a chunk when reading from an object store. The default is 8 MB. For large scale operations, it is recommended to increase this value to 64.
+            concurrent_fetches: [GCS] The number of concurrent fetches when reading from an object store. The default is 1. For large scale operations, it is recommended to increase this value to 8 or even more.
+            allow_anonymous: [GCS, AWS S3] Whether to allow anonymous access to object storage.
+            enable_request_payer: [AWS S3] Whether to enable request payer for object storage. This is useful for reading files from AWS S3 buckets that require request payer.
+            compression_type: The compression type of the FASTA file. If not specified, it will be detected automatically based on the file extension. BGZF and GZIP compressions are supported ('bgz', 'gz').
+            max_retries:  The maximum number of retries for reading the file from object storage.
+            timeout: The timeout in seconds for reading the file from object storage.
+
+        !!! Example
+            ```shell
+            wget https://www.ebi.ac.uk/ena/browser/api/fasta/BK006935.2?download=true -O /tmp/test.fasta
+            ```
+
+            ```python
+            import polars_bio as pb
+            pb.register_fasta("/tmp/test.fasta", "test_fasta")
+            pb.sql("select name, description from test_fasta limit 1").collect()
+            ```
+        """
+
+        object_storage_options = PyObjectStorageOptions(
+            allow_anonymous=allow_anonymous,
+            enable_request_payer=enable_request_payer,
+            chunk_size=chunk_size,
+            concurrent_fetches=concurrent_fetches,
+            max_retries=max_retries,
+            timeout=timeout,
+            compression_type=compression_type,
+        )
+
+        fasta_read_options = FastaReadOptions(
+            object_storage_options=object_storage_options,
+        )
+        read_options = ReadOptions(fasta_read_options=fasta_read_options)
+        py_register_table(ctx, path, name, InputFormat.Fasta, read_options)
 
     @staticmethod
     def register_bigwig(

--- a/tests/test_io_fasta.py
+++ b/tests/test_io_fasta.py
@@ -29,3 +29,10 @@ class TestFasta:
         )
 
         pl_testing.assert_frame_equal(df, expected_df)
+
+    def test_register_table(self):
+        pb.register_fasta(self.fasta_path, "test_fasta")
+        count = pb.sql("select count(*) as cnt from test_fasta").collect()
+        assert count["cnt"][0] == 2
+        names = pb.sql("select name from test_fasta order by name").collect()
+        assert names["name"].to_list() == ["seq1", "seq2"]


### PR DESCRIPTION
## Summary

Audit of per-format **eager/lazy/register** method coverage and documentation currency since the `0.31.0` tag, plus the one code gap it surfaced.

- **`register_fasta`** — FASTA was the only format missing a `register_*` method, breaking the eager/lazy/register triad. The Rust backend already supports `InputFormat::Fasta` registration, so this is a pure-Python wrapper (`polars_bio/sql.py`) plus export + `__all__` entry. Added a register test to `tests/test_io_fasta.py` (written test-first).
- **CHANGELOG** — backfilled the **0.27.0 → 0.31.0** sections (previously skipped: it jumped 0.26 → 0.22) and expanded `[Unreleased]` with the real post-0.31.0 work: BigWig/BigBed I/O (#393), VCF Zarr describe/register (#391), `register_fasta`, robust pushdown (#407), and the DataFusion 53 bump (#392).
- **`docs/features.md`** — added **VCF Zarr, BigWig, BigBed** rows to the file-formats support table (capabilities verified against the code — e.g. BigWig/BigBed ignore the scan limit, so limit-pushdown = ❌) and a BigWig/BigBed usage section. The page's "always three methods available" claim is now accurate for every format.

`api.md` is mkdocstrings-autogenerated and the new methods already have docstrings + `__all__` entries, so it needed no edits.

## Coverage after this PR

Every format now exposes `read_*` (eager), `scan_*` (lazy), and `register_*`.

## Test plan

- [x] `register_fasta` test fails without the implementation (RED), passes with it (GREEN)
- [x] `pytest tests/test_io_fasta.py tests/test_io_bed.py tests/test_fasta_write.py` → 30 passed
- [x] `ruff format --check` clean; pre-commit hooks (black/isort) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)