### PR TITLE
fix(bed): correct 0-based half-open coordinates for read_bed/scan_bed (#413)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,8 +1465,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1491,8 +1491,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bbi"
-version = "1.6.4"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.6.5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1503,8 +1503,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1526,8 +1526,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1548,8 +1548,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1574,8 +1574,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1597,8 +1597,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1621,8 +1621,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1649,8 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1674,8 +1674,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1702,8 +1702,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.8.5"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.5#9fbb3668057f671b23170f4d3b434357c22a1ec6"
+version = "1.8.6"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.6#24f1d588a836b2225cd2ab79282344befd38a88e"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,17 +28,17 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.5" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.6" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0", default-features = false }

--- a/tests/test_io_bed.py
+++ b/tests/test_io_bed.py
@@ -57,6 +57,76 @@ class TestBED:
         assert projection["chrom"][0] == "chr16"
         # Note: register_* functions currently use Rust-side default (0-based)
         # TODO: Update register_* to respect global config
+        # 0-based half-open coordinates match the on-disk BED record exactly
+        # (chr16  63917502  63934965). See issue #413: the end must NOT be
+        # decremented in 0-based mode.
         assert projection["start"][1] == 66700000
-        assert projection["end"][2] == 63934964
+        assert projection["end"][2] == 63934965
         assert projection["name"][4] == "FRA16E"
+
+
+class TestBEDCoordinateSystem:
+    """Regression tests for BED coordinate-system semantics (issue #413).
+
+    A BED file stores intervals as 0-based half-open ``[start, end)``. The
+    on-disk records in ``test.bed`` are::
+
+        chr1  1000  2000
+        chr2  1500  2500
+        chrX  5000  8000
+
+    Therefore the reader must produce:
+
+    * ``use_zero_based=True``  -> ``(start, end)``     unchanged (0-based half-open)
+    * ``use_zero_based=False`` -> ``(start + 1, end)``  (1-based closed)
+
+    The ``end`` coordinate is identical in both systems because a 1-based
+    *inclusive* end equals a 0-based *exclusive* end. Issue #413 reported that
+    ``use_zero_based=True`` incorrectly emitted ``end - 1`` (a 0-based *closed*
+    interval). The pre-existing value test only compared ``start``, so the
+    ``end`` regression went undetected.
+    """
+
+    bed_path = f"{DATA_DIR}/io/bed/test.bed"
+
+    # On-disk 0-based half-open coordinates (the source of truth).
+    file_starts = [1000, 1500, 5000]
+    file_ends = [2000, 2500, 8000]
+
+    def _sorted(self, df):
+        df = df.to_pandas().sort_values("start").reset_index(drop=True)
+        return df["start"].tolist(), df["end"].tolist()
+
+    def test_read_bed_zero_based_is_half_open(self):
+        starts, ends = self._sorted(pb.read_bed(self.bed_path, use_zero_based=True))
+        assert starts == self.file_starts, "0-based start must equal the file start"
+        # The crux of #413: end must NOT be decremented.
+        assert ends == self.file_ends, "0-based half-open end must equal the file end"
+
+    def test_read_bed_one_based_is_closed(self):
+        starts, ends = self._sorted(pb.read_bed(self.bed_path, use_zero_based=False))
+        assert starts == [s + 1 for s in self.file_starts], "1-based start = file + 1"
+        assert ends == self.file_ends, "1-based closed end must equal the file end"
+
+    def test_scan_bed_zero_based_is_half_open(self):
+        starts, ends = self._sorted(
+            pb.scan_bed(self.bed_path, use_zero_based=True).collect()
+        )
+        assert starts == self.file_starts
+        assert ends == self.file_ends, "scan_bed 0-based end must equal the file end"
+
+    def test_read_bed_end_identical_across_coordinate_systems(self):
+        _, ends_zero = self._sorted(pb.read_bed(self.bed_path, use_zero_based=True))
+        _, ends_one = self._sorted(pb.read_bed(self.bed_path, use_zero_based=False))
+        # Only the start differs by 1 between systems; the end is invariant.
+        assert ends_zero == ends_one == self.file_ends
+
+    def test_read_bed_preserves_interval_length(self):
+        z_starts, z_ends = self._sorted(pb.read_bed(self.bed_path, use_zero_based=True))
+        o_starts, o_ends = self._sorted(
+            pb.read_bed(self.bed_path, use_zero_based=False)
+        )
+        for i in range(len(self.file_starts)):
+            span = self.file_ends[i] - self.file_starts[i]
+            assert z_ends[i] - z_starts[i] == span, "half-open length mismatch"
+            assert o_ends[i] - o_starts[i] + 1 == span, "closed length mismatch"


### PR DESCRIPTION
## Summary

Fixes #413: `read_bed(use_zero_based=True)` / `scan_bed(use_zero_based=True)` returned **0-based closed** coordinates (`end - 1`) instead of the documented **0-based half-open** coordinates.

The defect was in the Rust backend (`datafusion-bio-formats`, `bio-format-bed`); the fix is biodatageeks/datafusion-bio-formats#211, released as **v1.8.6**. This PR bumps the dependency and adds the missing Python-side coverage.

## Validation

Validated with [oxbow](https://github.com/abdenlab/oxbow) as an independent reference reader against UCSC/ENCODE `ENCFF521CWX.bed` (114,800 records):

| | start | end |
|---|---:|---:|
| on-disk BED (0-based half-open) | 124229081 | 124229093 |
| oxbow (1-based closed ref) | 124229082 | 124229093 |
| `read_bed()` default | 124229082 | 124229093 |
| `read_bed(use_zero_based=True)` **before** | 124229081 | 124229092 ❌ |
| `read_bed(use_zero_based=True)` **after** | 124229081 | 124229093 ✅ |

After the fix, 0-based output matches the on-disk BED bytes exactly for all rows; default 1-based output matches oxbow byte-for-byte.

## Changes

- **Cargo.toml / Cargo.lock**: bump the `datafusion-bio-format-*` git deps to tag **v1.8.6** (contains the #211 fix).
- **tests/test_io_bed.py** — new `TestBEDCoordinateSystem`: validates `read_bed` and `scan_bed` in both coordinate systems, asserting **start AND end** plus interval-length preservation. The pre-existing `test_coordinate_system_metadata.py::...::test_bed_zero_vs_one_based_values` only checked `start`, which is why the `end` regression slipped through.
- **tests/test_io_bed.py** — `TestBED::test_register_table` previously asserted the buggy end value (`63934964`); `register_bed` uses the Rust-side 0-based default, so it now correctly returns the on-disk half-open end (`63934965`).

## Test plan

- [x] `pytest tests/test_io_bed.py tests/test_coordinate_system_metadata.py` → 122 passed (built against tag v1.8.6)
- [x] Upstream Rust tests in #211 (`coordinate_system_test.rs`) pass and fail-without-fix

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)