### PR TITLE
chore: release 0.32.0

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -28,7 +28,14 @@ verified sequence so a release is complete and consistent every time.
 | `Cargo.toml` | `version = "X.Y.Z"` under `[package]` |
 | `pyproject.toml` | `version = "X.Y.Z"` under `[project]` |
 | `polars_bio/__init__.py` | `__version__ = "X.Y.Z"` |
-| `Cargo.lock` | auto-updates for the `polars_bio` package on the next `cargo` run |
+| `Cargo.lock` | regenerate via `cargo check`; stage it |
+| `uv.lock` | regenerate via `uv lock`; stage it |
+
+> ⚠️ **Both lockfiles pin the project version.** CI's `linux_tests` job runs
+> `uv lock --check` and **fails the build** if `uv.lock` still shows the old
+> version. Always run `uv lock` after bumping `pyproject.toml`. Likewise
+> `cargo check` updates `Cargo.lock`. Forgetting either is the #1 way a release
+> PR goes red.
 
 ## Workflow
 
@@ -84,15 +91,16 @@ Use today's date (it's in the session context — do not invent one). Keep the
   grep -n "<NEW>" Cargo.toml pyproject.toml polars_bio/__init__.py CHANGELOG.md
   ```
 - **Compile** — `cargo check` (run in background; the workspace is large). Must exit 0.
-- **Lockfile** — confirm `Cargo.lock` now shows the new version for `polars_bio`
-  (`cargo check` regenerates it). Stage it.
+- **Lockfiles** — regenerate and stage BOTH:
+  - `cargo check` updates `Cargo.lock`; confirm `polars_bio` shows the new version.
+  - `uv lock` updates `uv.lock`; then `uv lock --check` must pass (CI runs this).
 - Report the readiness results plainly (pass/fail with evidence), per
   verification-before-completion.
 
 ### 6. Commit, push, open the PR
 
 ```bash
-git add CHANGELOG.md Cargo.toml Cargo.lock pyproject.toml polars_bio/__init__.py
+git add CHANGELOG.md Cargo.toml Cargo.lock pyproject.toml uv.lock polars_bio/__init__.py
 git commit   # message: "chore: release X.Y.Z"  (pre-commit hooks run black/isort)
 git push -u origin release/X.Y.Z
 gh pr create --title "chore: release X.Y.Z" --body "..."

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: prepare-release
+description: >-
+  Cut a new polars-bio release — bump the version, finalize the changelog, run
+  release-readiness checks, open the release PR, and draft a LinkedIn
+  announcement. Use this whenever the user asks to "prepare a release", "cut
+  X.Y.Z", "bump the version", "do the 0.32.0 release", "release readiness", or
+  anything about shipping a new polars-bio version. polars-bio keeps its version
+  in THREE places that must stay in lockstep (Cargo.toml, pyproject.toml,
+  polars_bio/__init__.py) plus the regenerated Cargo.lock — this skill exists so
+  none of them is forgotten and the changelog is cut correctly from
+  [Unreleased]. Reach for it before manually editing any version string.
+---
+
+# Preparing a polars-bio release
+
+## Why this exists
+
+polars-bio's version lives in **three** sources of truth that must always
+match, and a release is easy to get half-right (bump two of three files, forget
+to cut the changelog, skip the compile check). This skill encodes the exact,
+verified sequence so a release is complete and consistent every time.
+
+## The version lives in 3 places (+ lockfile)
+
+| File | Line shape |
+|------|------------|
+| `Cargo.toml` | `version = "X.Y.Z"` under `[package]` |
+| `pyproject.toml` | `version = "X.Y.Z"` under `[project]` |
+| `polars_bio/__init__.py` | `__version__ = "X.Y.Z"` |
+| `Cargo.lock` | auto-updates for the `polars_bio` package on the next `cargo` run |
+
+## Workflow
+
+Track these as todos so none is skipped.
+
+### 1. Establish the version and what's shipping
+
+- Current version: `git describe --tags --abbrev=0` and `grep version Cargo.toml`.
+- Commits since last tag: `git log --oneline <last-tag>..HEAD`.
+- Decide the new version with the user if not given (semver: breaking → minor
+  while pre-1.0, features → minor, fixes → patch). polars-bio has been bumping
+  the **minor** for feature releases (0.30 → 0.31 → 0.32).
+- Cross-check `git log` against the `[Unreleased]` section of `CHANGELOG.md` —
+  **the most recent merged PRs are often missing**. Add anything absent (check
+  the latest commit/PR especially, e.g. a last-minute fix).
+
+### 2. Create the release branch
+
+```bash
+git checkout -b release/X.Y.Z
+```
+
+Never bump version on `master` directly — it goes through a PR.
+
+### 3. Bump the version in all 3 files
+
+Edit each of `Cargo.toml`, `pyproject.toml`, `polars_bio/__init__.py`. Match on
+the surrounding line (e.g. `name = "polars_bio"` above the Cargo version) so the
+edit is unambiguous.
+
+### 4. Cut the changelog
+
+`CHANGELOG.md` follows Keep a Changelog. Convert the open `[Unreleased]` heading
+into a dated release heading, leaving a fresh empty `[Unreleased]` above it:
+
+```markdown
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+...
+```
+
+Use today's date (it's in the session context — do not invent one). Keep the
+`### Added / Changed / Fixed` subsections that were already accumulated.
+
+### 5. Release-readiness checks (do not skip)
+
+- **Version consistency** — confirm zero stragglers and all three at the new version:
+  ```bash
+  grep -rn "<OLD>" Cargo.toml pyproject.toml polars_bio/__init__.py   # expect: no matches
+  grep -n "<NEW>" Cargo.toml pyproject.toml polars_bio/__init__.py CHANGELOG.md
+  ```
+- **Compile** — `cargo check` (run in background; the workspace is large). Must exit 0.
+- **Lockfile** — confirm `Cargo.lock` now shows the new version for `polars_bio`
+  (`cargo check` regenerates it). Stage it.
+- Report the readiness results plainly (pass/fail with evidence), per
+  verification-before-completion.
+
+### 6. Commit, push, open the PR
+
+```bash
+git add CHANGELOG.md Cargo.toml Cargo.lock pyproject.toml polars_bio/__init__.py
+git commit   # message: "chore: release X.Y.Z"  (pre-commit hooks run black/isort)
+git push -u origin release/X.Y.Z
+gh pr create --title "chore: release X.Y.Z" --body "..."
+```
+
+End the commit message with the standard `Co-Authored-By:` trailer and the PR
+body with the standard Claude Code generation line.
+
+The PR body should list the highlights since the last release (Added / Changed /
+Fixed, with PR numbers) and the release-readiness results.
+
+### 7. Draft the LinkedIn announcement
+
+See `references/linkedin-template.md`. Emoji-led, scannable, one emoji per
+highlight, ends with `pip install polars-bio==X.Y.Z`, a GitHub star CTA, and
+genomics/Python/Rust hashtags. Show it to the user — they post it manually.
+
+## What this skill does NOT do
+
+- It does not tag or publish to PyPI/crates.io — that's the maintainer's CI on
+  merge. Stop at the PR + announcement draft unless the user asks for more.
+- It does not edit upstream `datafusion-bio-formats` versions.

--- a/.claude/skills/prepare-release/references/linkedin-template.md
+++ b/.claude/skills/prepare-release/references/linkedin-template.md
@@ -1,0 +1,46 @@
+# LinkedIn announcement template
+
+Goal: a scannable, emoji-led post that a non-bioinformatician scrolling their
+feed will still find inviting. One emoji per highlight, lead with the punchiest
+features, keep paragraphs to one or two lines.
+
+## Structure
+
+1. **Hook** — 🧬 + one line: what polars-bio is + the version, with energy.
+2. **Highlights** — 3–6 bullets, each `<emoji> **Name** — plain-language value`.
+   Order by impact, not by changelog section. Translate changelog jargon into
+   user benefit ("less data scanned, faster queries" beats "predicate pushdown").
+3. **Install** — `📦 pip install polars-bio==X.Y.Z`
+4. **CTA** — ⭐ star on GitHub: https://github.com/biodatageeks/polars-bio
+5. **Hashtags** — #Bioinformatics #Genomics #Python #Rust #DataFusion #Polars
+   #OpenSource #ComputationalBiology
+
+## Emoji palette (reuse for consistency across releases)
+
+- 🧬 the project / genomics
+- 🚀 ⚡ speed / performance
+- 📊 signal & track formats (BigWig/BigBed)
+- 🧊 Zarr / array-native
+- 🧫 FASTA / sequence
+- 🔧 engine / dependency bumps
+- 🐛 bug fixes / reliability
+- 📦 install   ⭐ star CTA
+
+## Example (0.32.0)
+
+> 🧬 **polars-bio 0.32.0 is out!** Blazing-fast genomic operations on large
+> Python dataframes, now with even broader format coverage. 🚀
+>
+> 📊 **BigWig & BigBed I/O** — first-class read/scan/register for signal &
+> interval tracks, local + cloud, lazy or eager.
+> 🧊 **VCF Zarr, leveled up** — `describe_vcf_zarr()` + `register_vcf_zarr()`.
+> 🧫 **FASTA register API** — `register_fasta()` completes the triad.
+> ⚡ **Robust pushdown** across all formats — less data scanned, faster queries.
+> 🔧 **DataFusion 53** under the hood.
+> 🐛 **Reliability fixes** — multi-member gzip FASTQ, count(*) on registered
+> FASTQ, correct 0-based half-open BED coordinates.
+>
+> 📦 `pip install polars-bio==0.32.0`
+> ⭐ https://github.com/biodatageeks/polars-bio
+>
+> #Bioinformatics #Genomics #Python #Rust #DataFusion #Polars #OpenSource #ComputationalBiology

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-06-30
+
 ### Added
 - BigWig and BigBed I/O APIs (#393)
   - `read_bigwig()`, `scan_bigwig()`, `register_bigwig()` and
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SELECT count(*)` on a FASTQ table registered via `register_fastq()` (#412)
 - Removed the unsupported `parallel` kwarg from `register_fastq` (#409, #410)
 - Normalize FASTQ columns before writing (#401)
+- `read_bed` / `scan_bed` now emit correct 0-based half-open coordinates
+  (#413, #415)
 - Consume the upstream bare VCF INFO key parser fix (#389)
 
 ## [0.31.0] - 2026-05-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4824,7 +4824,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 
 [lib]

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -123,7 +123,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.31.0"
+version = "0.32.0"
 description = "Blazing fast genomic operations on large Python dataframes"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2891,7 +2891,7 @@ wheels = [
 
 [[package]]
 name = "polars-bio"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "datafusion" },


### PR DESCRIPTION
## Release 0.32.0

Cuts the `[Unreleased]` changelog into `[0.32.0]` and bumps the version across all three sources of truth.

### Version bumps (3 places)
- `Cargo.toml` → `0.32.0` (+ `Cargo.lock`)
- `pyproject.toml` → `0.32.0`
- `polars_bio/__init__.py` `__version__` → `0.32.0`

### Highlights since 0.31.0
**Added**
- BigWig / BigBed I/O APIs — `read/scan/register_bigwig` and `read/scan/register_bigbed` (#393)
- VCF Zarr `describe_vcf_zarr()` and `register_vcf_zarr()` (#391)
- `register_fasta()` completing the eager/lazy/register triad for FASTA (#414)

**Changed**
- Robust predicate & projection pushdown across formats (#407, fixes #396)
- DataFusion stack bumped to 53; pyarrow floor raised (#392)

**Fixed**
- Multi-member gzip FASTQ now fully decoded (#408)
- `SELECT count(*)` on `register_fastq()` tables (#412)
- Removed unsupported `parallel` kwarg from `register_fastq` (#409, #410)
- FASTQ column normalization on write (#401)
- `read_bed` / `scan_bed` 0-based half-open coordinates (#413, #415)
- Upstream bare VCF INFO key parser fix (#389)

### Release readiness
- ✅ All 3 version files consistent at `0.32.0`, no `0.31.0` stragglers
- ✅ `Cargo.lock` regenerated
- ✅ `cargo check` passes
- ✅ pre-commit hooks (black, isort, python ast) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)