### PR TITLE
feat: add optional jemalloc global allocator (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Optional **jemalloc** global allocator behind the `jemalloc` Cargo feature (#402).
+  Off by default; enable with `maturin build --features jemalloc` on Linux/macOS
+  (no-op on Windows/MSVC, which keeps the system allocator). On the single-thread
+  interval-operation benchmark suite jemalloc was ~12% faster with equal-or-lower
+  peak memory than the default system allocator.
+
 ## [0.32.0] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,6 +4852,7 @@ dependencies = [
  "pyo3-log",
  "rand 0.8.6",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -6340,6 +6341,26 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "polars_bio"
 version = "0.32.0"
 edition = "2021"
 
+[features]
+# Opt-in jemalloc global allocator (issue #402). Off by default.
+# Enable with `--features jemalloc` on Linux/macOS; it is a no-op on Windows/MSVC
+# (tikv-jemallocator does not support the MSVC target), which keeps the system
+# allocator there. Benchmarks: ~12% faster and lower peak RSS vs the default
+# allocator on the single-thread interval-operation suite.
+jemalloc = ["dep:tikv-jemallocator"]
+
 [lib]
 name = "polars_bio"
 crate-type= ["cdylib"]
@@ -14,6 +22,8 @@ crate-type= ["cdylib"]
 datafusion-python = { version = "53.0.0", default-features = false }
 pyo3 = { version = "0.28.3", features = ["extension-module", "abi3"] }
 pyo3-log = "0.13.3"
+# Optional jemalloc allocator, gated behind the `jemalloc` feature (see [features]).
+tikv-jemallocator = { version = "0.6", optional = true }
 
 
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,13 @@ mod scan;
 mod utils;
 mod write;
 
+// Opt-in jemalloc global allocator (issue #402), enabled with `--features jemalloc`.
+// Excluded on Windows/MSVC, where tikv-jemallocator is unsupported; that target keeps
+// the system allocator.
+#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::string::ToString;
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

Adds an **opt-in** `jemalloc` Cargo feature (off by default) that installs
[`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) as the global
allocator. Addresses #402.

- **Off by default** — enable with `maturin build --features jemalloc` (Linux/macOS).
- **Gated to non-MSVC targets** (`cfg(not(target_env = "msvc"))`), so Windows keeps the
  system allocator (`tikv-jemallocator` doesn't support MSVC).
- **Default builds are byte-identical to before** — no allocator is compiled in unless
  the feature is enabled.

```rust
#[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
#[global_allocator]
static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
```

## Why jemalloc (and not mimalloc)

I benchmarked default vs mimalloc vs jemalloc on the single-thread interval-operation
suite (databio, 8 operations, `POLARS_MAX_THREADS=1`, `-C target-cpu=native`, macOS
arm64). Two reasons jemalloc wins:

1. **jemalloc is faster *and* leaner.** Runtime geomean **−12.3%** vs default, with
   equal-or-lower peak RSS. mimalloc was faster too (−9.3%) but cost **+36–40% peak RSS**
   on reduce ops (`merge`/`complement`) because it retains freed segments.
2. **mimalloc v3 (the crate default) segfaults at `import` on macOS arm64** — a load-time
   `EXC_BAD_ACCESS` in `mi_bbitmap_try_find_and_clear`. It only works if pinned to the
   `v2` feature. jemalloc has no such issue.

### Runtime, vs default (geomean of per-case ratios)

| operation | jemalloc Δ% |
|:--|--:|
| merge | −23.5% |
| count_overlaps | −17.6% |
| coverage | −16.1% |
| cluster | −12.8% |
| complement | −12.0% |
| nearest | −7.0% |
| overlap | −4.1% |
| subtract | −2.3% |
| **overall** | **−12.3%** |

### Peak memory (whole-run RSS, identical workload)

| allocator | peak | Δ vs default |
|:--|--:|--:|
| default (system) | 14.95 GiB | baseline |
| jemalloc | 14.19 GiB | **−5.0%** |
| mimalloc v2 | 21.19 GiB | +41.8% |

> Numbers are macOS-laptop, single-thread, **directional** — macOS libmalloc is slow, so
> the win overstates a Linux release build. Full data (per-op runtime + per-op peak/avg
> RSS) lives in the `polars-bio-bench` repo (`results/alloc-impact-summary.md`).

## Verification

- `RUSTFLAGS="-Dwarnings" cargo check` (default) and `--features jemalloc` both clean.
- Built the `--features jemalloc` wheel and confirmed `import polars_bio` + an `overlap`
  run succeed on macOS arm64.

## Follow-ups (not in this PR)

- Since the feature is off by default, the **published PyPI wheels do not include it**.
  To ship jemalloc to end users, add `--features jemalloc` to the maturin args in the
  Linux/macOS jobs of `.github/workflows/publish_to_pypi.yml` (leave Windows untouched).
- A **Linux, ideally multi-threaded, confirmation run** is worth doing before flipping it
  on in wheels — multithreaded allocation is where jemalloc typically helps most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
