### PR TITLE
fix(overlap): prevent py3.12/3.13 segfault on eager-then-lazy overlap (#395)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,22 @@ const LEFT_TABLE: &str = "s1";
 const RIGHT_TABLE: &str = "s2";
 const DEFAULT_COLUMN_NAMES: [&str; 3] = ["contig", "start", "end"];
 
+/// Deregister the reusable `s1`/`s2` range-operation tables, dropping whatever
+/// was registered by a previous call.
+///
+/// MUST be called while the GIL is held. The dropped tables may hold Arrow
+/// batches whose buffers are owned by Python (imported over the Arrow C Data
+/// Interface from polars/pyarrow); their FFI release callback runs
+/// `_PyObject_Free`, which is only safe under the GIL. Doing this here — instead
+/// of letting the re-registration drop them inside a `py.detach` block on a
+/// GIL-free worker thread — is what prevents the issue #395 segfault, while
+/// keeping the batches themselves zero-copy.
+fn deregister_range_tables(py_ctx: &PyBioSessionContext) {
+    let ctx = &py_ctx.ctx;
+    let _ = ctx.deregister_table(LEFT_TABLE);
+    let _ = ctx.deregister_table(RIGHT_TABLE);
+}
+
 #[pyfunction]
 #[pyo3(signature = (py_ctx, df1, df2, range_options, limit=None))]
 fn range_operation_frame(
@@ -80,6 +96,17 @@ fn range_operation_frame(
         .0
         .collect::<Result<Vec<datafusion::arrow::array::RecordBatch>, datafusion::arrow::error::ArrowError>>()
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    // Drop any previously-registered s1/s2 tables while the GIL is held (issue #395).
+    // The batches held by those tables keep their buffers alive through the Arrow
+    // C Data Interface, and for Python-exported inputs (polars/pyarrow) the FFI
+    // release callback runs `_PyObject_Free` — which corrupts memory unless the GIL
+    // is held. If the drop instead happened inside the `py.detach` below (on a
+    // GIL-free DataFusion worker thread) it segfaults non-deterministically. The
+    // registration inside `py.detach` then has nothing left to drop off-GIL. This
+    // keeps the imported batches zero-copy: the only unsafe moment is the *drop*,
+    // which we now always perform here under the GIL.
+    deregister_range_tables(py_ctx);
 
     // Now release GIL for the actual computation (registration and join)
     #[allow(clippy::useless_conversion)]
@@ -142,6 +169,13 @@ fn range_operation_lazy(
     let reader1 = stream1.0;
     let reader2 = stream2.0;
 
+    // Drop any previously-registered s1/s2 tables while the GIL is held (issue #395).
+    // A prior *eager* overlap leaves Python-owned Arrow batches under these names;
+    // dropping them inside the `py.detach` below (on a GIL-free worker thread) runs
+    // `_PyObject_Free` off-GIL and segfaults. Deregistering here removes them under
+    // the GIL, so the registration inside `py.detach` has nothing left to drop.
+    deregister_range_tables(py_ctx);
+
     // Release GIL for the actual computation (registration and join)
     // The Arrow C Streams have been extracted - no more Python interaction needed
     py.detach(|| {
@@ -190,6 +224,14 @@ fn range_operation_scan(
     read_options2: Option<ReadOptions>,
     limit: Option<usize>,
 ) -> PyResult<PyDataFrame> {
+    // Drop any previously-registered s1/s2 tables while the GIL is held (issue #395).
+    // File-path overlaps re-register s1/s2 inside the `py.detach` below (via
+    // `maybe_register_table` -> `register_table` -> `deregister_table`). If the
+    // previous call was an eager DataFrame overlap, those names still hold
+    // Python-owned Arrow batches, and dropping them off-GIL there hits the same
+    // `_PyObject_Free` hazard. Deregistering here under the GIL closes that path.
+    deregister_range_tables(py_ctx);
+
     #[allow(clippy::useless_conversion)]
     py.detach(|| {
         let rt = Runtime::new()?;

--- a/tests/test_issue_395_eager_lazy_segfault.py
+++ b/tests/test_issue_395_eager_lazy_segfault.py
@@ -1,0 +1,104 @@
+"""Regression test for issue #395.
+
+An eager ``pb.overlap(DataFrame, DataFrame)`` followed by a lazy
+``pb.overlap(LazyFrame, LazyFrame).collect()`` in the same process used to
+segfault non-deterministically. Root cause: the eager path registered Arrow
+batches whose buffers were still owned by Python (imported over the Arrow C
+Data Interface from ``polars`` / ``pyarrow``). Those tables live in the shared,
+long-lived session context, and the *next* range operation dropped them while
+re-registering the ``s1``/``s2`` tables -- on a GIL-free worker thread. The
+Arrow FFI release callback then ran ``_PyObject_Free`` without the GIL, which
+corrupts memory. The fix drops those tables under the GIL before the
+``py.detach`` block. See ``src/lib.rs::deregister_range_tables``.
+
+Only the ``eager -> lazy`` direction is exercised: it is the dangerous one. A
+lazy overlap registers Rust-owned Arrow streams (no Python FFI release
+callbacks), so ``lazy -> eager`` is safe even on the buggy build; the crash
+needs a *prior eager* table (Python-owned batches) to be dropped off-GIL by the
+next op.
+
+The crash is timing dependent, so we drive the eager->lazy pattern many times
+in a *subprocess* and assert it exits cleanly. A regression re-introduces the
+segfault, which shows up as a non-zero (139) exit code instead of taking down
+the whole test session.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+# On the buggy build this pattern segfaults well within a few hundred
+# iterations (observed 8/8 crashes at 400). Use a healthy margin.
+_ITERATIONS = 400
+
+_WORKER = textwrap.dedent(
+    """
+    import sys
+    import numpy as np
+    import polars as pl
+    import polars_bio as pb
+
+    pb.set_option("datafusion.bio.coordinate_system_check", "false")
+    pb.set_option("datafusion.bio.coordinate_system_zero_based", True)
+
+    def eager(contig):
+        queries = pl.DataFrame({
+            "chrom": [contig] * 3,
+            "start": np.array([0, 100, 200], dtype=np.int64),
+            "end":   np.array([50, 150, 250], dtype=np.int64),
+        })
+        table = pl.DataFrame({
+            "chrom": [contig] * 3,
+            "start": np.array([10, 110, 210], dtype=np.int64),
+            "end":   np.array([20, 130, 230], dtype=np.int64),
+            "sample_id": ["s1", "s2", "s3"],
+            "value": np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        })
+        return pb.overlap(
+            queries, table,
+            cols1=["chrom", "start", "end"], cols2=["chrom", "start", "end"],
+            output_type="polars.DataFrame",
+        ).height
+
+    def lazy(contig):
+        lf_table = pl.DataFrame({
+            "index": np.arange(3, dtype=np.int32),
+            "chrom": [contig] * 3,
+            "start": np.array([14, 104, 204], dtype=np.int64),
+            "end":   np.array([16, 106, 206], dtype=np.int64),
+        }).lazy()
+        lf_queries = pl.DataFrame({
+            "chrom": [contig] * 3,
+            "start": np.array([0, 100, 200], dtype=np.int64),
+            "end":   np.array([50, 150, 250], dtype=np.int64),
+        }).lazy().with_row_index("query")
+        return pb.overlap(
+            lf_queries, lf_table,
+            cols1=["chrom", "start", "end"], cols2=["chrom", "start", "end"],
+            projection_pushdown=True,
+        ).collect().height
+
+    contigs = ["chr1", "chr19", "chr20"]
+    n = int(sys.argv[1])
+    for i in range(n):
+        c = contigs[i % len(contigs)]
+        eager(c)   # eager DataFrame overlap registers Python-owned batches
+        lazy(c)    # lazy overlap re-registers s1/s2 -> used to drop them off-GIL
+    print("OK")
+    """
+)
+
+
+def test_eager_then_lazy_overlap_does_not_segfault():
+    result = subprocess.run(
+        [sys.executable, "-c", _WORKER, str(_ITERATIONS)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"eager->lazy overlap loop exited with {result.returncode} "
+        f"(negative/139 => segfault regression of issue #395)\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

Fixes #395 — a non-deterministic segfault on **Python 3.12/3.13** when an eager `pb.overlap(DataFrame, DataFrame)` is followed by a lazy `pb.overlap(LazyFrame, LazyFrame).collect()` in the same process.

## Root cause

Confirmed with a native backtrace from a macOS crash report:

```
tokio-runtime-worker  EXC_BAD_ACCESS
  Python::detach                                    ← range_operation_lazy
  register_frame_from_arrow_stream_with_partitions  ← deregister/register s1/s2
  drop StreamingTable → RecordBatchPartitionStream   ← the PRIOR eager table
  → ReleaseExportedArray (pyarrow C ABI)
  → polars_arrow::ffi::c_release_array
  → _PyObject_Free                                   ← frees a Python object OFF-GIL → crash
```

The eager path registers Arrow batches imported over the Arrow C Data Interface from `polars`/`pyarrow` as the reusable `s1`/`s2` tables in the **long-lived singleton session context**. Those buffers keep a **Python object alive through their FFI release callback** (which ends in `_PyObject_Free`).

The Arrow release callback only fires on the **last** reference drop. During a join, DataFusion workers drop clones (never the last ref — the registered table holds the originals), so those are harmless. The last drop happens when the **next** range operation re-registers `s1`/`s2` — and that re-registration runs inside `py.detach`, i.e. on a **GIL-free worker thread**. Running `_PyObject_Free` without the GIL corrupts memory. This is why only the *alternation* triggers it: eager-only and lazy-only are each safe.

Single-shot runs crash rarely (~0/40); an in-process alternating loop crashes reliably (~8/8 at 400 iterations).

## Fix (zero-copy)

Deregister the `s1`/`s2` tables at the top of `range_operation_frame` and `range_operation_lazy`, **while the GIL is still held**, before entering `py.detach`. This performs the only GIL-sensitive operation — the drop of the previous call's tables — under the GIL. The re-registration inside `py.detach` then has nothing left to drop off-GIL.

The imported batches stay **zero-copy**: nothing is copied, only the *moment of their final drop* is moved under the GIL. (An earlier revision of this PR deep-copied the eager inputs into Rust-owned buffers; that also worked but defeated zero-copy and added a memcpy of both inputs on every eager overlap. Switched to this smaller, allocation-free fix.)

## Testing

- New `tests/test_issue_395_eager_lazy_segfault.py` drives the eager→lazy pattern in a subprocess and asserts a clean exit (a regression re-appears as exit 139, not a killed test session).
- Before the fix: alternating loop segfaults 8/8 at 400 iters. After: **0 segfaults** across 20×600-iter stress runs + the exact issue reproducer.
- Full suite green (1070 passed / 1 skipped) on the current `master` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
