### PR TITLE
fix(depth): 0-based output is half-open, not closed (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pb.depth(..., use_zero_based=True)` returned 0-based **closed** coordinate
+  blocks instead of the documented 0-based half-open, so every block covered one
+  base fewer than its 1-based counterpart and summing block widths understated
+  coverage. `pos_end` is now exclusive in 0-based mode. Fixed upstream in
+  `datafusion-bio-function-pileup`
+  (biodatageeks/datafusion-bio-functions#204, #205); verified against
+  `mosdepth --fast-mode` and `samtools depth -a` (#427)
+
 ## [0.33.0] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,8 +1742,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.14.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=d8f48e07bf90faad54f4470433119a7d7f44af84#d8f48e07bf90faad54f4470433119a7d7f44af84"
+version = "0.14.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.14.1#5c52657d58b6068bcf9aa196b8f7c2b0a6a34409"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,8 +1742,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
+version = "0.14.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=d8f48e07bf90faad54f4470433119a7d7f44af84#d8f48e07bf90faad54f4470433119a7d7f44af84"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-
 datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.7" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0", default-features = false }
+# Pinned to the #427 half-open coordinate fix (biodatageeks/datafusion-bio-functions#205).
+# Switch back to a tag once that lands in a release.
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "d8f48e07bf90faad54f4470433119a7d7f44af84", default-features = false }
 # Phase-1 FastQC, released in datafusion-bio-functions v0.13.x
 # (merged biodatageeks/datafusion-bio-functions#182).
 datafusion-bio-function-fastqc = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.13.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-
 datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.7" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
-# Pinned to the #427 half-open coordinate fix (biodatageeks/datafusion-bio-functions#205).
-# Switch back to a tag once that lands in a release.
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "d8f48e07bf90faad54f4470433119a7d7f44af84", default-features = false }
+# v0.14.1 carries the #427 half-open coordinate fix
+# (biodatageeks/datafusion-bio-functions#205).
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.14.1", default-features = false }
 # Phase-1 FastQC, released in datafusion-bio-functions v0.13.x
 # (merged biodatageeks/datafusion-bio-functions#182).
 datafusion-bio-function-fastqc = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.13.1" }

--- a/tests/test_pileup.py
+++ b/tests/test_pileup.py
@@ -91,6 +91,85 @@ def test_depth_one_based():
     assert get_coordinate_system(lf) is False
 
 
+# ── Coordinate values (issue #427) ─────────────────────────────────────
+#
+# These assert actual coordinates, not just the schema metadata flag.
+# use_zero_based=True used to emit 0-based *closed* blocks, so every block
+# covered one base fewer than documented; the metadata-only tests above
+# passed throughout.
+
+
+@pytest.mark.parametrize("path", [BAM_PATH, SAM_PATH, CRAM_PATH])
+def test_depth_zero_based_blocks_are_half_open(path):
+    """0-based output is half-open: pos_end is exclusive, so it equals the
+    1-based closed end while pos_start is one lower."""
+    one_based = pb.depth(path, use_zero_based=False).collect()
+    zero_based = pb.depth(path, use_zero_based=True).collect()
+
+    assert zero_based.height == one_based.height
+    assert zero_based.height > 0
+
+    assert (zero_based["pos_start"] == one_based["pos_start"] - 1).all()
+    assert (zero_based["pos_end"] == one_based["pos_end"]).all()
+    assert (zero_based["coverage"] == one_based["coverage"]).all()
+
+
+@pytest.mark.parametrize("path", [BAM_PATH, SAM_PATH, CRAM_PATH])
+def test_depth_coordinate_systems_cover_the_same_bases(path):
+    """Switching coordinate system must not change how many bases a block
+    covers: 1-based closed spans end - start + 1, 0-based half-open spans
+    end - start."""
+    one_based = pb.depth(path, use_zero_based=False).collect()
+    zero_based = pb.depth(path, use_zero_based=True).collect()
+
+    closed_widths = one_based["pos_end"] - one_based["pos_start"] + 1
+    half_open_widths = zero_based["pos_end"] - zero_based["pos_start"]
+
+    assert (closed_widths == half_open_widths).all()
+    assert closed_widths.sum() == half_open_widths.sum()
+    assert (half_open_widths > 0).all(), "half-open blocks must be non-empty"
+
+
+def test_depth_zero_based_blocks_chain_without_gaps_or_overlap():
+    """The defining property of half-open intervals: where two blocks abut,
+    one block's end *is* the next block's start. Under the old closed output
+    abutting blocks were off by one and could not be chained."""
+    df = (
+        pb.depth(CRAM_PATH, use_zero_based=True).collect().sort(["contig", "pos_start"])
+    )
+
+    starts = df["pos_start"].to_list()
+    ends = df["pos_end"].to_list()
+    contigs = df["contig"].to_list()
+
+    assert all(e > s for s, e in zip(starts, ends)), "every block must be non-empty"
+
+    abutting = 0
+    for i in range(len(df) - 1):
+        if contigs[i] != contigs[i + 1]:
+            continue
+        assert ends[i] <= starts[i + 1], (
+            f"blocks overlap: [{starts[i]}, {ends[i]}) then "
+            f"[{starts[i + 1]}, {ends[i + 1]})"
+        )
+        if ends[i] == starts[i + 1]:
+            abutting += 1
+
+    # This fixture is one continuous pileup, so consecutive blocks abut.
+    # With closed ends, ends[i] would be starts[i + 1] - 1 and this is 0.
+    assert abutting > 0, "no block chained into the next — ends are not exclusive"
+
+
+def test_depth_zero_based_first_block_can_start_at_zero():
+    """A read at the first base of a contig yields pos_start == 0 in 0-based
+    output, and its end is still exclusive."""
+    df = pb.depth(CRAM_PATH, use_zero_based=True).collect().sort("pos_start")
+
+    first = df.row(0, named=True)
+    assert first["pos_start"] == 0
+    assert first["pos_end"] > first["pos_start"]
+
+
 def test_depth_is_truly_lazy():
     """depth() returns LazyFrame with correct schema without executing pileup."""
     lf = pb.depth(BAM_PATH)

--- a/tests/test_pileup_samtools.py
+++ b/tests/test_pileup_samtools.py
@@ -63,6 +63,24 @@ def _expand_blocks(blocks: pl.DataFrame) -> pl.DataFrame:
     )
 
 
+def _expand_blocks_zero_based(blocks: pl.DataFrame) -> pl.DataFrame:
+    """Expand 0-based half-open blocks into per-position rows.
+
+    pos_end is exclusive here, so the range runs to pos_end rather than
+    pos_end + 1. Positions are shifted to 1-based for comparison against the
+    samtools golden file.
+    """
+    return (
+        blocks.filter(pl.col("coverage") > 0)
+        .with_columns(
+            pl.int_ranges(pl.col("pos_start"), pl.col("pos_end")).alias("pos")
+        )
+        .explode("pos")
+        .select(["contig", (pl.col("pos") + 1).cast(pl.Int32), "coverage"])
+        .sort(["contig", "pos"])
+    )
+
+
 def _run_blocks(partitions: int) -> pl.DataFrame:
     """Run block-mode depth with given partition count, return expanded sorted rows."""
     key = ("blocks", partitions)
@@ -74,6 +92,22 @@ def _run_blocks(partitions: int) -> pl.DataFrame:
     finally:
         pb.set_option("datafusion.execution.target_partitions", "1")
     result = _expand_blocks(blocks)
+    _CACHE[key] = result
+    gc.collect()
+    return result
+
+
+def _run_blocks_zero_based(partitions: int) -> pl.DataFrame:
+    """Run 0-based block-mode depth, return expanded rows shifted to 1-based."""
+    key = ("blocks_zero_based", partitions)
+    if key in _CACHE:
+        return _CACHE[key]
+    pb.set_option("datafusion.execution.target_partitions", str(partitions))
+    try:
+        blocks = pb.depth(BAM_PATH, use_zero_based=True).collect()
+    finally:
+        pb.set_option("datafusion.execution.target_partitions", "1")
+    result = _expand_blocks_zero_based(blocks)
     _CACHE[key] = result
     gc.collect()
     return result
@@ -126,3 +160,35 @@ def test_blocks_vs_per_base(partitions):
 
     assert blocks_expanded.height == per_base.height
     assert blocks_expanded.equals(per_base)
+
+
+# ── 0-based half-open blocks vs samtools (issue #427) ─────────────────
+#
+# Everything above runs with use_zero_based=False, which is why the 0-based
+# off-by-one in #427 went unnoticed against this golden dataset.
+
+
+@pytest.mark.parametrize("partitions", [1, 2, 4])
+def test_zero_based_blocks_vs_samtools(samtools_golden, partitions):
+    """0-based half-open blocks, expanded with an exclusive end and shifted to
+    1-based, must exactly match samtools depth."""
+    result = _run_blocks_zero_based(partitions)
+
+    assert result.height == samtools_golden.height, (
+        f"Row count mismatch (partitions={partitions}): "
+        f"got {result.height}, expected {samtools_golden.height}. "
+        "A short count means 0-based ends are inclusive rather than exclusive."
+    )
+
+    assert result.equals(
+        samtools_golden
+    ), f"Coverage mismatch (partitions={partitions})"
+
+
+def test_zero_based_and_one_based_cover_the_same_bases(samtools_golden):
+    """Both coordinate systems must describe the same covered positions."""
+    zero_based = _run_blocks_zero_based(1)
+    one_based = _run_blocks(1)
+
+    assert zero_based.height == one_based.height == samtools_golden.height
+    assert zero_based.equals(one_based)


### PR DESCRIPTION
pb.depth(..., use_zero_based=True) returned 0-based *closed* blocks instead of the documented half-open. Both coordinates were shifted down by one while the interval stayed closed, so every block covered one base fewer than its 1-based counterpart — on tests/data/io/cram/test.cram, summing block widths gave 36 bases instead of 117.

The defect is upstream: PileupConfig::zero_based reached the BAM/CRAM provider and the schema metadata but never the coverage-block emitters, which hardcoded an inclusive end. Fixed in
biodatageeks/datafusion-bio-functions#205; pin the pileup dep to that rev until it lands in a release.

Tests: the existing coordinate-system tests only asserted the schema metadata flag, and the samtools golden-parity suite ran exclusively with use_zero_based=False, so nothing covered the actual 0-based coordinates. Add value-level tests over BAM/SAM/CRAM (half-open ends, the equal-width invariant across systems, block chaining, first-block-at-zero) and extend the NA12878 10k golden suite with a 0-based parity test across 1/2/4 partitions.

All 12 new tests fail against the previous pileup pin and pass on the fix, while the 28 pre-existing pileup tests pass either way — which is precisely why this reached users. Against the golden dataset the old build recovers 19,888 of 21,155 covered positions.

<!--
Thanks for contributing to polars-bio! 🎉
Please fill in the sections below. You can delete sections that don't apply.
-->

## Description

<!-- What does this PR do and why? A short summary of the change. -->

## Related issue

<!-- Link the issue this PR addresses, e.g. "Closes #123". -->
Closes #

## Type of change

<!-- Put an `x` in the boxes that apply. -->

- [ x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📖 Documentation update
- [ ] 🧹 Refactor / chore / CI (no functional change)
- [ ] ⚡ Performance improvement

## How has this been tested?

<!-- Describe the tests you ran and how to reproduce them. Include commands and, if
relevant, hardware/OS and data used. -->

## Checklist

- [ ] My code follows the style and conventions of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have added or updated tests that prove my fix is effective or my feature works.
- [ ] New and existing unit tests pass locally (`python -m pytest`) and, for Rust changes, `cargo check` / `cargo test` pass.
- [ ] I have run `maturin develop --release` and verified the change works end-to-end where applicable.
- [ ] I have updated the documentation (docstrings, `docs/`) as needed.
- [ ] I have updated `CHANGELOG.md` under `[Unreleased]` where user-facing behavior changed.
- [ ] My changes generate no new warnings.
- [ ] I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Additional notes

<!-- Screenshots, benchmarks, breaking-change migration notes, or anything else reviewers should know. -->
