### PR TITLE
docs: explain how to suppress progress output

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,14 @@
 
     We recommend handling most of the heavy lifting on the DataFusion side (e.g., using SQL and views) and relying on Polars' streaming capabilities primarily for projection, filtering, and sinking results. See the [Polars Integration](developers.md#polars-integration) section for more details on the architecture.
 
-2. What to do if I get  `Illegal instruction (core dumped)` when using polars-bio?
+2. How can I suppress the processed-row progress output?
+
+    Set the `TQDM_DISABLE` environment variable to `1` before importing
+    `polars_bio` or `tqdm`. See
+    [Reading files: Progress output](features/reading.md#progress-output) for
+    shell and Python examples.
+
+3. What to do if I get  `Illegal instruction (core dumped)` when using polars-bio?
 This error is likely due to the fact that the ABI of the polars-bio wheel package does not match the ABI of the Python interpreter.
 To fix this, you can build the wheel package from source. See [Quickstart](quickstart.md) for more information.
 ```bash
@@ -19,7 +26,7 @@ To fix this, you can build the wheel package from source. See [Quickstart](quick
 polars-bio-intel kernel: [ 1611.175045] traps: python[8844] trap invalid opcode ip:709d3ec253cc sp:7ffcc28754e8 error:0 in polars_bio.abi3.so[709d36533000+9aab000]
 ```
 
-3. How to build the documentation?
+4. How to build the documentation?
    To build the documentation, you need to install the `polars-bio` package and then run the following command in the root directory of the repository:
 ```bash
 MKDOCS_EXPORTER_PDF=false JUPYTER_PLATFORM_DIRS=1 mkdocs serve  -w polars_bio
@@ -29,12 +36,12 @@ Some pages of the documentation take a while to build—to speed up the process,
 MKDOCS_EXPORTER_PDF=false ENABLE_MD_EXEC=false ENABLE_MKDOCSTRINGS=false ENABLE_JUPYTER=false JUPYTER_PLATFORM_DIRS=1 mkdocs serve
 ```
 
-4. How to build the source code and install in the current virtual environment?
+5. How to build the source code and install in the current virtual environment?
 ```bash
 RUSTFLAGS="-Ctarget-cpu=native" maturin develop --release  -m Cargo.toml
 ```
 
-5. How to run the integration tests?
+6. How to run the integration tests?
    To run the integration tests, you need to have the `azure-cli`, `docker`, and `pytest` installed. Then, you can run the following commands:
 ```bash
 cd it

--- a/docs/features/reading.md
+++ b/docs/features/reading.md
@@ -36,6 +36,28 @@ The matrix below summarizes which [performance features](#performance-features) 
 
 polars-bio applies the same performance machinery — indexing, pushdown, and parallel reads — across most formats. The [capability matrix](#file-formats-support) above shows which format supports what; this section explains each feature and how to use it.
 
+### Progress output
+
+When polars-bio streams batches from DataFusion into Polars, it displays the
+number of processed rows and throughput on stderr. To suppress this progress
+output for the whole process, set `TQDM_DISABLE=1` when starting Python:
+
+```bash
+TQDM_DISABLE=1 python analysis.py
+```
+
+You can also set the environment variable in Python. Set it at the start of the
+process, before importing `polars_bio` or any other module that imports `tqdm`,
+because `tqdm` reads environment overrides when it is imported:
+
+```python
+import os
+
+os.environ["TQDM_DISABLE"] = "1"
+
+import polars_bio as pb
+```
+
 ### Indexed reads & random access
 
 When an index file is present alongside the data file (BAI/CSI for BAM, CRAI for CRAM, TBI/CSI for VCF, GFF, and Pairs), polars-bio can push genomic region filters down to the DataFusion execution layer. This enables **index-based random access** — only the relevant genomic regions are read from disk, dramatically improving performance for selective queries on large files.


### PR DESCRIPTION
## Description

Documents the supported way to suppress polars-bio's processed-row throughput
output on stderr:

- explains that the output is provided by `tqdm`
- shows both shell and Python examples using `TQDM_DISABLE=1`
- calls out that the variable must be set before `tqdm` is imported
- adds a discoverable FAQ entry that links to the detailed reading guide

This lets users keep stderr clean without redirecting unrelated warnings or
errors. The underlying behavior already existed; the missing piece was user-facing
guidance.

## Related issue

Closes #428

## Type of change

- [x] 📖 Documentation update

## How has this been tested?

- Verified `TQDM_DISABLE=1` disables a `tqdm(unit="rows")` instance when set in
  the shell and at the start of Python.
- Built the documentation with dynamic content disabled:
  `MKDOCS_EXPORTER_PDF=false ENABLE_MD_EXEC=false ENABLE_MKDOCSTRINGS=false ENABLE_JUPYTER=false JUPYTER_PLATFORM_DIRS=1 mkdocs build --quiet`.
- Confirmed the rendered FAQ link resolves to the new `#progress-output` section.
- Ran `git diff --check` and the repository pre-commit hooks for the documentation
  commit.

## Checklist

- [x] My changes follow the style and conventions of this project.
- [x] I have performed a self-review.
- [x] I have updated the documentation as needed.
- [x] My changes generate no new warnings.
- [x] I have read and agree to the Code of Conduct.

## Additional notes

`mkdocs build --strict` still reports the repository's existing warnings about
missing Cairo and unresolved API anchors; none refer to the new section or FAQ
link. The normal documentation build succeeds.
