### PR TITLE
chore: release 0.33.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: polars-bio version
       description: "Run: `python -c 'import polars_bio; print(polars_bio.__version__)'`"
-      placeholder: "0.33.0"
+      placeholder: "0.33.1"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-08-02
+
 ### Added
 
 - Indexed CRAM scans now return the unplaced, unmapped reads at the end of a file.
@@ -45,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Document how unmapped reads behave across indexed and sequential scans (see
   [Reading files](https://biodatageeks.github.io/polars-bio/features/reading/#unmapped-reads-and-indexed-scans))
+- Explain how to suppress processed-row progress output with `TQDM_DISABLE`
+  (#432)
 
 ## [0.33.0] - 2026-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,7 +4794,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2021"
 
 [features]
@@ -72,4 +72,3 @@ async-trait = "0.1.86"
 futures = "0.3.31"
 rand = "0.8.5"
 serde_json = "1.0"
-

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -126,7 +126,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.33.0"
+__version__ = "0.33.1"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.33.0"
+version = "0.33.1"
 description = "Blazing fast genomic operations on large Python dataframes"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2869,7 +2869,7 @@ wheels = [
 
 [[package]]
 name = "polars-bio"
-version = "0.33.0"
+version = "0.33.1"
 source = { editable = "." }
 dependencies = [
     { name = "datafusion" },


### PR DESCRIPTION
## Description

Prepare polars-bio 0.33.1 for release:

- bump the package version in Cargo, Python metadata, the Python module, both lockfiles, and the bug-report template
- cut the 2026-08-02 changelog from `[Unreleased]`
- include the latest progress-output documentation change (#432)

## Release highlights

### Added

- Indexed whole-file CRAM scans now retain unplaced, unmapped reads, matching sequential scans.

### Fixed

- `pb.depth(..., use_zero_based=True)` now returns documented 0-based half-open blocks (#427, #430).
- CRAM files using Huffman-coded bases no longer abort during reads (#429, #431).
- Multi-record CRAI indexes are parsed correctly.

### Changed

- The CRAM dependency stack now uses one rebased `noodles` revision.

### Documentation

- Document indexed versus sequential behavior for unmapped reads.
- Explain suppressing processed-row progress output with `TQDM_DISABLE` (#432).

## Validation

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `uv lock --check`
- [x] `git diff --check`
- [x] Version consistency across Cargo, Python metadata/module, and both lockfiles
