### PR TITLE
fix(test): surface pyBigWig loader failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
   "pysam",
   "pyranges1==1.3.8; python_version >= '3.12' and python_version < '3.14'",
   # pyBigWig is the reference for the BBI parity tests; manylinux wheels exist
-  # for 3.11-3.13. On 3.14 the tests importorskip and are skipped.
+  # for 3.11-3.13. On 3.14 the missing dependency skips the parity module.
   "pyBigWig>=0.3.22; python_version < '3.14'",
 ]
 
@@ -91,3 +91,8 @@ benchmark = [
 
 [tool.uv]
 default-groups = ["dev"]
+
+[tool.uv.extra-build-variables]
+# pyBigWig publishes no macOS wheels. This build revision invalidates older uv
+# source-build wheels that were linked without an LC_RPATH.
+pybigwig = { POLARS_BIO_PYBIGWIG_BUILD_REVISION = "1" }

--- a/tests/data/io/bbi/VALIDATION.md
+++ b/tests/data/io/bbi/VALIDATION.md
@@ -10,7 +10,7 @@ predicate-pushdown fix ([datafusion-bio-formats#205], tag `v1.8.3`).
 |------|----------------|--------|
 | `tests/test_io_bbi.py` | no | API, schema, autoSQL/rest, coordinate conversion, pushdown == client-side, register/SQL path |
 | `tests/test_io_bbi_streaming.py` | no | lazy scan, `limit` pushdown across batch boundaries, streaming vs in-memory engine equality, streaming aggregation, region pushdown unclipped |
-| `tests/test_io_bbi_parity.py` | yes (`importorskip`) | row-for-row equality vs pyBigWig (bigWig intervals, bigBed `rest`), pushdown-region parity |
+| `tests/test_io_bbi_parity.py` | yes (missing dependency skips; load errors fail) | row-for-row equality vs pyBigWig (bigWig intervals, bigBed `rest`), pushdown-region parity |
 
 Fixtures are committed under `tests/data/io/bbi/`. `large_signal.bw` (95 KB,
 20,000 intervals on chr1 + 5,000 on chr2) is generated with pyBigWig so the

--- a/tests/test_io_bbi_parity.py
+++ b/tests/test_io_bbi_parity.py
@@ -1,17 +1,21 @@
 """Parity tests: polars-bio BBI readers vs pyBigWig (the de-facto reference).
 
-Skipped automatically where pyBigWig is not installed. Validates that the
-polars-bio output matches libBigWig row-for-row on the committed fixtures, and
-that predicate pushdown returns the same rows as a client-side filter.
+Skipped automatically only where pyBigWig is not installed. Import failures
+from an installed but unusable extension are errors, so the parity checks cannot
+be reported as skipped when pyBigWig has a broken native-library dependency.
 """
 
+import importlib.util
 from pathlib import Path
 
 import numpy as np
 import polars as pl
 import pytest
 
-pyBigWig = pytest.importorskip("pyBigWig")
+if importlib.util.find_spec("pyBigWig") is None:
+    pytest.skip("pyBigWig is not installed", allow_module_level=True)
+
+import pyBigWig  # noqa: E402
 
 import polars_bio as pb  # noqa: E402
 

--- a/tests/test_io_bbi_parity_dependency.py
+++ b/tests/test_io_bbi_parity_dependency.py
@@ -1,0 +1,35 @@
+"""Regression tests for the pyBigWig parity-test dependency boundary."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+PARITY_TEST = ROOT / "tests" / "test_io_bbi_parity.py"
+
+
+def test_pybigwig_loader_error_fails_parity_test_collection(tmp_path):
+    """An installed but unloadable pyBigWig must not turn into a test skip."""
+    (tmp_path / "pyBigWig.py").write_text(
+        'raise ImportError("synthetic pyBigWig loader failure")\n'
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(tmp_path), env.get("PYTHONPATH")))
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", str(PARITY_TEST)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 2, output
+    assert "ERROR collecting tests/test_io_bbi_parity.py" in output
+    assert "synthetic pyBigWig loader failure" in output


### PR DESCRIPTION
## Summary

- invalidate stale uv-cached macOS pyBigWig source builds with a tracked build revision
- skip BBI parity tests only when pyBigWig is absent, while surfacing native-loader failures
- add regression coverage for an installed but unloadable pyBigWig module

## Root cause

pyBigWig does not publish macOS wheels. uv could reuse an older locally built wheel whose extension referenced @rpath/libz.1.dylib without carrying an LC_RPATH, causing import failure in the development environment.

## Testing

- `uv run --extra test pytest tests/test_io_bbi_parity.py -ra -q` (4 passed without skips)
- focused parity and dependency regression suite (5 passed)
- `uv lock --check`
- Ruff lint and formatting checks
- repository pre-commit hooks

Closes #437