### PR TITLE
chore: release 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-20
+
 ### Added
 
 - BGEN 1.2/1.3 support: `read_bgen()`, `scan_bgen()`, `describe_bgen()`, and
@@ -37,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   APIs. BCF keeps
   `genotype_output="string"|"dosage"`, CSI predicate pushdown, and parallel
   partition processing.
+- polars-bio is now published on Bioconda:
+  `conda install -c conda-forge -c bioconda polars-bio` (linux-64, osx-64,
+  osx-arm64). Its one unpackaged dependency, `polars-config-meta`, was published
+  on conda-forge first (#426)
 
 ### Changed
 
@@ -51,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BCF metadata now identifies its source format as `bcf`, and format detection
   for VCF/BCF range operations ignores signed-URL query parameters and fragments.
+
+### Documentation
+
+- Quickstart documents the conda/mamba install alongside pip, with the platform
+  and extras caveats, and the README carries Bioconda version, downloads and
+  platform badges. The `update_bioconda_recipe` workflow is removed — Bioconda's
+  autobump bot already watches the recipe's PyPI source URL and Mergify
+  auto-merges its bump PRs (#438)
 
 ## [0.33.1] - 2026-08-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,7 +4887,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.33.1"
+version = "0.34.0"
 edition = "2021"
 
 [features]

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -141,7 +141,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.33.1"
+__version__ = "0.34.0"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.33.1"
+version = "0.34.0"
 description = "Blazing fast genomic operations on large Python dataframes"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2869,7 +2869,7 @@ wheels = [
 
 [[package]]
 name = "polars-bio"
-version = "0.33.1"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "datafusion" },


### PR DESCRIPTION
Cuts the 0.34.0 release: version bumped in all three sources of truth plus both
lockfiles, and `[Unreleased]` closed into a dated `0.34.0` section.

## Highlights since 0.33.1

### Added

- **BGEN 1.2/1.3** — `read_bgen()`, `scan_bgen()`, `describe_bgen()`,
  `register_bgen()`. `genotype_output="probability"` keeps every format-defined
  probability state, `"dosage"` emits the expected copy count of `alleles[1]`, a
  neighbouring `.bgi` drives `chrom`/`rsid`/`id`/`start`/`end` pushdown, and
  `probability_layout="fixed"` drops per-sample offsets for uniform-width files
  (#436)
- **PLINK 2 PGEN** — `read_pgen()`, `scan_pgen()`, `describe_pgen()`,
  `register_pgen()`. One row per PVAR variant, `genotype_fields` selects the
  `genotypes` struct children (`GT`, `ALT_COUNT`, `PHASED`, `DS`, `DS_STORED`,
  `HDS`), plus read-coalescing knobs for object storage (#436)
- **Dense matrix readers** — `read_pgen_matrix()` / `read_bgen_matrix()` return a
  whole cohort as a `(variants, samples)` NumPy array, decoded straight to its
  final address and in source order at every thread count (#436)
- **`genotype_fields` for BGEN** — skip the per-genotype ploidy byte on a dosage
  read (#436)
- **Native BCF APIs** — `read_bcf()`, `scan_bcf()`, `describe_bcf()`,
  `register_bcf()`, with `genotype_output`, CSI pushdown and parallel partitions
  (#435)
- **Bioconda** — `conda install -c conda-forge -c bioconda polars-bio`
  (linux-64, osx-64, osx-arm64); `polars-config-meta` was published on
  conda-forge first (#426)

### Changed

- **Breaking:** the VCF methods accept text VCF only, and no longer expose
  `genotype_output` or the deprecated `genotype_encoding_raw`. Use the BCF
  methods for `.bcf` input (#435)
- `genotype_encoding_raw` stays on `read_vcf_zarr()` / `scan_vcf_zarr()` (#435)

### Fixed

- BCF metadata reports its source format as `bcf`, and VCF/BCF range-operation
  format detection ignores signed-URL query parameters and fragments (#435)

### Documentation

- Quickstart covers the conda/mamba install with platform and extras caveats;
  README gains Bioconda badges; the redundant `update_bioconda_recipe` workflow
  is removed in favour of Bioconda's autobump bot + Mergify (#438)

## Release-readiness

| Check | Result |
|---|---|
| `Cargo.toml` / `pyproject.toml` / `polars_bio/__init__.py` | all `0.34.0`, no `0.33.1` stragglers |
| `cargo check` | exit 0 — `Checking polars_bio v0.34.0`, finished in 43.27s |
| `Cargo.lock` | `polars_bio` at `0.34.0` |
| `uv lock` | `polars-bio v0.33.1 -> v0.34.0` |
| `uv lock --check` | passes (CI's `linux_tests` gate) |

Changelog entries for #426 and #438 were missing from `[Unreleased]` and have
been added here. #439 (`fix(test): surface pyBigWig loader failures`) is
test-only and is deliberately not in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
