### PR TITLE
docs(readme): add the Bioconda "install with bioconda" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/polars-bio)
 ![GitHub License](https://img.shields.io/github/license/biodatageeks/polars-bio)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/polars-bio)
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://bioconda.github.io/recipes/polars-bio/README.html)
 [![Bioconda](https://img.shields.io/conda/vn/bioconda/polars-bio?label=bioconda)](https://anaconda.org/bioconda/polars-bio)
 [![Bioconda - Downloads](https://img.shields.io/conda/dn/bioconda/polars-bio?label=bioconda%20downloads)](https://anaconda.org/bioconda/polars-bio)
 [![Bioconda - Platforms](https://img.shields.io/conda/pn/bioconda/polars-bio?label=platforms)](https://anaconda.org/bioconda/polars-bio)


### PR DESCRIPTION
Adds the canonical Bioconda badge from the recipe page's **Link to this page**
section:

```markdown
[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://bioconda.github.io/recipes/polars-bio/README.html)
```

It sits just above the three Bioconda badges we already carry. Those report
state (version, downloads, platforms) and all point at anaconda.org; this one
points at the recipe page itself, where the install command and the per-platform
builds are documented.

One deviation from the snippet Bioconda hands out: the link is `https://` rather
than `http://`, since the http form redirects.

Verified both endpoints resolve:

| URL | Result |
|---|---|
| `img.shields.io/badge/install%20with-bioconda-brightgreen.svg` | 200, `image/svg+xml` |
| `bioconda.github.io/recipes/polars-bio/README.html` | 200, no redirect |

Branched from `origin/master`, so it is independent of #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)