### PR TITLE
docs: correct the GTF parallel and FASTQ projection cells

### DIFF
--- a/docs/features/reading.md
+++ b/docs/features/reading.md
@@ -28,7 +28,7 @@ The matrix below summarizes which [performance features](#performance-features) 
 | [FASTQ](../api/reading.md#polars_bio.data_input.read_fastq) | :white_check_mark: | :white_check_mark: (GZI) | :white_check_mark: |  ❌  |  ❌   |
 | [FASTA](../api/reading.md#polars_bio.data_input.read_fasta) | :white_check_mark: |  ❌  | :white_check_mark: |  ❌  |  ❌   |
 | [GFF3](../api/reading.md#polars_bio.data_input.read_gff)    | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
-| [GTF](../api/reading.md#polars_bio.data_input.read_gtf)     | :white_check_mark: | ❌                  | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
+| [GTF](../api/reading.md#polars_bio.data_input.read_gtf)     | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [Pairs](../api/reading.md#polars_bio.data_input.read_pairs) | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [BGEN](../api/reading.md#polars_bio.data_input.read_bgen)   | :white_check_mark: | :white_check_mark: (BGI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [PGEN](../api/reading.md#polars_bio.data_input.read_pgen)   | :white_check_mark: | :white_check_mark: (embedded/PGI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
@@ -76,6 +76,7 @@ Index files are **auto-discovered** by convention. Predicate pushdown is **enabl
 | VCF (bgzf) | TBI, CSI | `sample.vcf.gz.tbi`, `sample.vcf.gz.csi` |
 | BCF | CSI | `sample.bcf.csi` |
 | GFF (bgzf) | TBI, CSI | `sample.gff.gz.tbi`, `sample.gff.gz.csi` |
+| GTF (bgzf) | TBI, CSI | `sample.gtf.gz.tbi`, `sample.gtf.gz.csi` |
 | Pairs (bgzf) | TBI, CSI | `contacts.pairs.gz.tbi`, `contacts.pairs.gz.csi` |
 | FASTQ (bgzf) | GZI | `sample.fastq.bgz.gzi` |
 

--- a/docs/features/reading.md
+++ b/docs/features/reading.md
@@ -25,7 +25,7 @@ The matrix below summarizes which [performance features](#performance-features) 
 | [VCF Zarr](../api/reading.md#polars_bio.data_input.read_vcf_zarr) | :white_check_mark: | :white_check_mark: (region index) | ❌ | :white_check_mark: | :white_check_mark: |
 | [BAM](../api/reading.md#polars_bio.data_input.read_bam)     | :white_check_mark: | :white_check_mark: (BAI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | [CRAM](../api/reading.md#polars_bio.data_input.read_cram)   | :white_check_mark: | :white_check_mark: (CRAI) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| [FASTQ](../api/reading.md#polars_bio.data_input.read_fastq) | :white_check_mark: | :white_check_mark: (GZI) | :white_check_mark: |  ❌  |  ❌   |
+| [FASTQ](../api/reading.md#polars_bio.data_input.read_fastq) | :white_check_mark: | :white_check_mark: (GZI) | :white_check_mark: |  ❌  | :white_check_mark: |
 | [FASTA](../api/reading.md#polars_bio.data_input.read_fasta) | :white_check_mark: |  ❌  | :white_check_mark: |  ❌  |  ❌   |
 | [GFF3](../api/reading.md#polars_bio.data_input.read_gff)    | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [GTF](../api/reading.md#polars_bio.data_input.read_gtf)     | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |


### PR DESCRIPTION
Two cells in the capability matrix in `docs/features/reading.md` are wrong. Each is verified by measurement, not by reading the source.

## 1. GTF supports indexed parallel scans

`GtfTableProvider` discovers a TBI/CSI index via `discover_gff_index` and partitions from `estimate_sizes_from_tbi` + `balance_partitions` — the same tabix path GFF3 uses.

Planning a `count(*)` at `target_partitions=4` on the pinned dependency (v1.10.0):

| input | plan above the scan | scan partitions |
|---|---|---|
| GTF + `.tbi` | `AggregateExec: mode=Partial` -> `GtfExec` | **4** |
| GTF, no index | `AggregateExec: mode=Partial` -> `RepartitionExec: RoundRobinBatch(4), input_partitions=1` -> `GtfExec` | 1 |

Same 16,000 rows either way. `input_partitions=1` is the scan reporting that it is serial — with the index, no `RepartitionExec` is inserted at all.

GTF is also added to the supported-index table, which listed GFF but not the format that reuses its index discovery.

## 2. FASTQ does push projection into the reader

The FASTQ reader creates an Arrow builder only for projected columns and gates each per-record copy on it:

```rust
let mut sequences = proj_indices.is_none_or(|p| p.contains(&2)).then(StringBuilder::new);
...
if let Some(b) = &mut sequences { ... }
```

An unselected sequence or quality string is never copied. Measured over 1M records, one thread: `SELECT *` 0.204 s vs `SELECT name` 0.148 s (**1.4x**), and `count(*)` 0.129 s via the empty-projection path (`FastqExec: projection=[]`).

## What I checked and did *not* change

An earlier revision of this PR suggested BED and FASTA were understated too. **That was wrong, and the measurement is what caught it.** Both parse every field into intermediate `Vec`s regardless and apply the projection only when assembling the Arrow batch:

| format | `SELECT *` | one column | ratio |
|---|---|---|---|
| BED, 3M rows | 0.818 s | 0.785 s | 1.04x |
| FASTA, 500k records | 0.095 s | 0.090 s | 1.05x |

The scan does emit only the requested columns (`BedExec: projection=[chrom]`), but the reader does no less work — so the existing value is the honest one, and both rows are left alone.

For contrast, where the matrix already says supported the saving is real: **VCF** 1.594 s -> 0.340 s for one of 40 columns (**4.7x**), **BAM** 1.663 s -> 0.904 s for one of 12 (**1.8x**), both over 2M rows.

The parallel column is also confirmed correct for the rows not touched here: BAM + `.bai` partitions 4 ways, while **SAM** (the BAM provider skips index discovery for SAM), **bigWig** and **bigBed** (`Partitioning::UnknownPartitioning(1)`) are all serial at the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
