### PR TITLE
docs(readme): add Python version and platform badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # polars-bio - Next-gen Python DataFrame operations for genomics!
 ![PyPI - Version](https://img.shields.io/pypi/v/polars-bio)
+[![Python versions](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue?logo=python&logoColor=white)](https://pypi.org/project/polars-bio/)
+[![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20macOS%20%7C%20windows-lightgrey)](https://pypi.org/project/polars-bio/#files)
 ![GitHub License](https://img.shields.io/github/license/biodatageeks/polars-bio)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/polars-bio)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://bioconda.github.io/recipes/polars-bio/README.html)
 [![Bioconda](https://img.shields.io/conda/vn/bioconda/polars-bio?label=bioconda)](https://anaconda.org/bioconda/polars-bio)
 [![Bioconda - Downloads](https://img.shields.io/conda/dn/bioconda/polars-bio?label=bioconda%20downloads)](https://anaconda.org/bioconda/polars-bio)
-[![Bioconda - Platforms](https://img.shields.io/conda/pn/bioconda/polars-bio?label=platforms)](https://anaconda.org/bioconda/polars-bio)
+[![Bioconda - Platforms](https://img.shields.io/conda/pn/bioconda/polars-bio?label=bioconda%20platforms)](https://anaconda.org/bioconda/polars-bio)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/biodatageeks/polars-bio)
 [![](https://dcbadge.limes.pink/api/server/https://discord.gg/bpxQ4Yxhk5?style=flat)](https://discord.gg/bpxQ4Yxhk5)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ classifiers = [
   "Programming Language :: Rust",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
   "polars>=1.37.1",


### PR DESCRIPTION
## What

The README's only platform badge was the Bioconda one (`conda/pn`), which renders `linux-64 | osx-arm64 | osx-64` — so the README reads as "no Windows support" even though every release ships a `win_amd64` wheel on PyPI. There was also no badge for the supported Python versions.

- **New platforms badge** covering the published wheels: `linux | macOS | windows`, linking to the PyPI files page.
- **Relabelled** the Bioconda badge to `bioconda platforms`, so its narrower list is self-explanatory rather than looking like a contradiction.
- **New Python versions badge**: `3.11 | 3.12 | 3.13 | 3.14`, matching `requires-python = ">=3.11,<3.15"` and the CI test matrix.

## Why a static Python badge

`img.shields.io/pypi/pyversions/polars-bio` currently renders **`python: missing`** — the published metadata has no `Programming Language :: Python :: 3.x` classifiers. This PR adds those classifiers (plus the OS classifiers) to `pyproject.toml`; once the next release is on PyPI the static badge can be swapped for the dynamic `pypi/pyversions` one.

## Verification

Fetched all three badge SVGs from shields.io:

| URL | rendered title |
| --- | --- |
| `badge/python-3.11...3.14-blue` | `python: 3.11 \| 3.12 \| 3.13 \| 3.14` |
| `badge/platforms-linux...windows` | `platforms: linux \| macOS \| windows` |
| `conda/pn/bioconda/polars-bio?label=bioconda%20platforms` | `bioconda platforms: linux-64 \| osx-arm64 \| osx-64` |

Windows wheel presence confirmed against the PyPI JSON API for 0.34.0 (`polars_bio-0.34.0-cp310-abi3-win_amd64.whl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)