### PR TITLE
feat(bbi): enable parallel BigWig and BigBed scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- BigWig and BigBed full scans now use their built-in BBI index to balance
+  compressed blocks across `datafusion.execution.target_partitions`. No sidecar
+  index is required, and partitioned scans preserve every row exactly once.
+
 ## [0.34.0] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated `datafusion-bio-formats` to v1.11.0 and
+  `datafusion-bio-functions` to v0.18.0.
 - BigWig and BigBed full scans now use their built-in BBI index to balance
   compressed blocks across `datafusion.execution.target_partitions`. No sidecar
   index is required, and partitioned scans preserve every row exactly once.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,9 +662,8 @@ dependencies = [
 
 [[package]]
 name = "bigtools"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1b9bbf6596d602e472a23ed5aa5d611fb04f14e7772226fb61c720e806202e"
+version = "0.5.9-dev"
+source = "git+https://github.com/biodatageeks/bigtools.git?rev=0d7a5728eb39ee97fddef59cd3da469186bec90d#0d7a5728eb39ee97fddef59cd3da469186bec90d"
 dependencies = [
  "byteorder",
  "byteordered",
@@ -1500,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1526,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bbi"
 version = "1.8.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1538,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1561,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bgen"
 version = "0.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1581,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1604,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1630,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1653,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1677,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1704,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1728,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1755,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pgen"
 version = "0.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1774,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,8 +1498,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1524,8 +1524,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bbi"
-version = "1.8.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.9.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1536,8 +1536,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1559,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bgen"
-version = "0.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "0.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1579,8 +1579,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1602,8 +1602,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1628,8 +1628,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1651,8 +1651,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1675,8 +1675,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1702,8 +1702,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1726,8 +1726,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1753,8 +1753,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pgen"
-version = "0.2.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "0.3.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1772,8 +1772,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=b7b3a81f9d1775484cdf55dc4cb957a145124bef#b7b3a81f9d1775484cdf55dc4cb957a145124bef"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1803,8 +1803,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-fastqc"
-version = "0.12.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.13.1#623b27ba152a6122a5a7ff3041e0c43c43805d27"
+version = "0.17.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.18.0#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
 dependencies = [
  "datafusion",
  "futures",
@@ -1813,8 +1813,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-pileup"
-version = "0.14.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.14.1#5c52657d58b6068bcf9aa196b8f7c2b0a6a34409"
+version = "0.18.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.18.0#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1827,8 +1827,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-ranges"
-version = "0.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
+version = "0.18.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.18.0#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
 dependencies = [
  "ahash",
  "async-trait",
@@ -6290,8 +6290,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superintervals"
-version = "0.13.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.11.0#1ad88df646e8db634a95822f77edaf0123e1b75b"
+version = "0.20.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.18.0#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
 dependencies = [
  "aligned-vec",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ pyo3-log = "0.13.3"
 
 
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats
-# v1.10.0 / datafusion-bio-functions v0.14.1, which pin datafusion to "=53.0.0". Restore
-# 53.1.0 once those crates publish releases built against datafusion 53.1.0.
+# v1.11.0 / datafusion-bio-functions v0.18.0, which pin datafusion to "=53.0.0".
+# Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
 arrow-schema = "58.3.0"
@@ -48,27 +48,23 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
 
-datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
-# v0.14.1 carries the #427 half-open coordinate fix
-# (biodatageeks/datafusion-bio-functions#205).
-datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.14.1", default-features = false }
-# Phase-1 FastQC, released in datafusion-bio-functions v0.13.x
-# (merged biodatageeks/datafusion-bio-functions#182).
-datafusion-bio-function-fastqc = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.13.1" }
+datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.18.0" }
+datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.18.0", default-features = false }
+datafusion-bio-function-fastqc = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.18.0" }
 
 async-trait = "0.1.86"
 futures = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,19 +48,19 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "b7b3a81f9d1775484cdf55dc4cb957a145124bef" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.11.0" }
 # v0.14.1 carries the #427 half-open coordinate fix

--- a/docs/features/reading.md
+++ b/docs/features/reading.md
@@ -32,8 +32,8 @@ The matrix below summarizes which [performance features](#performance-features) 
 | [Pairs](../api/reading.md#polars_bio.data_input.read_pairs) | :white_check_mark: | :white_check_mark: (TBI/CSI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [BGEN](../api/reading.md#polars_bio.data_input.read_bgen)   | :white_check_mark: | :white_check_mark: (BGI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
 | [PGEN](../api/reading.md#polars_bio.data_input.read_pgen)   | :white_check_mark: | :white_check_mark: (embedded/PGI) | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
-| [BigWig](../api/reading.md#polars_bio.data_input.read_bigwig) | :white_check_mark: | ❌ | ❌ | :white_check_mark: | :white_check_mark: |
-| [BigBed](../api/reading.md#polars_bio.data_input.read_bigbed) | :white_check_mark: | ❌ | ❌ | :white_check_mark: | :white_check_mark: |
+| [BigWig](../api/reading.md#polars_bio.data_input.read_bigwig) | :white_check_mark: | :white_check_mark: (built-in BBI index) | ❌ | :white_check_mark: | :white_check_mark: |
+| [BigBed](../api/reading.md#polars_bio.data_input.read_bigbed) | :white_check_mark: | :white_check_mark: (built-in BBI index) | ❌ | :white_check_mark: | :white_check_mark: |
 
 ## Performance features
 
@@ -573,6 +573,12 @@ Full registry includes ~40 common SAM tags.
 [BigBed](https://genome.ucsc.edu/goldenPath/help/bigBed.html) (feature intervals) are
 supported through the same eager/lazy/register access patterns. Predicate pushdown on the
 genomic coordinate columns and projection pushdown are enabled by default.
+
+Parallel scans use each file's built-in cir-tree (R-tree) index, so BigWig and
+BigBed do not need a sidecar index. The reader balances compressed data blocks
+across up to `datafusion.execution.target_partitions` independent partitions;
+small files can expose fewer partitions than requested when they contain fewer
+independent indexed work units.
 
 ```python
 import polars as pl

--- a/openspec/changes/add-bigwig-bigbed-support/tasks.md
+++ b/openspec/changes/add-bigwig-bigbed-support/tasks.md
@@ -13,7 +13,7 @@
 - [x] 2.3 Implement projection flags for `chrom`, `start`, `end`, and `value`.
 - [x] 2.4 Implement genomic filter analysis and interval-region pruning for `chrom`, `start`, and `end`.
 - [ ] 2.5 Implement provider-side residual filtering for `value` comparisons when feasible.
-- [ ] 2.6 Implement partition planning from DataFusion `target_partitions`.
+- [x] 2.6 Implement partition planning from DataFusion `target_partitions`.
 - [ ] 2.7 Add provider tests for full scan, projected scan, genomic predicate scan, value residual filter, empty projection/count, and partition count.
 
 ## 3. DataFusion BigBed Provider
@@ -24,7 +24,7 @@
 - [x] 3.4 Implement projection flags so non-projected extra fields are not parsed.
 - [x] 3.5 Implement genomic filter analysis and interval-region pruning for `chrom`, `start`, and `end`.
 - [ ] 3.6 Implement provider-side residual filtering for supported parsed scalar fields when feasible.
-- [ ] 3.7 Implement partition planning and boundary ownership filtering.
+- [x] 3.7 Implement partition planning and boundary ownership filtering.
 - [ ] 3.8 Add provider tests for autoSQL schema, fallback `rest`, projection, genomic predicates, scalar residual predicates, empty projection/count, and partition count.
 
 ## 4. Rust/PyO3 Integration
@@ -61,4 +61,4 @@
 - [ ] 7.1 Update API docs for BigWig and BigBed read/scan/register methods.
 - [ ] 7.2 Document initial storage limitations and coordinate semantics.
 - [ ] 7.3 Add examples for selecting BigWig signal columns and filtering BigBed annotations by genomic interval.
-- [ ] 7.4 Add changelog entry.
+- [x] 7.4 Add changelog entry.

--- a/openspec/changes/add-bigwig-bigbed-support/tasks.md
+++ b/openspec/changes/add-bigwig-bigbed-support/tasks.md
@@ -52,7 +52,7 @@
 - [ ] 6.3 Test `use_zero_based=True`, `use_zero_based=False`, and global default behavior.
 - [ ] 6.4 Test projection pushdown returns only requested columns and plan output includes `BigWigExec` or `BigBedExec` projection details.
 - [x] 6.5 Test genomic predicate pushdown against equivalent non-pushdown results.
-- [ ] 6.6 Test parallel partition behavior by setting `datafusion.execution.target_partitions`.
+- [x] 6.6 Test parallel partition behavior by setting `datafusion.execution.target_partitions`.
 - [x] 6.7 Test BigBed autoSQL field parsing and fallback `rest` behavior.
 - [ ] 6.8 Test unsupported remote paths fail with clear errors.
 

--- a/tests/data/io/bbi/VALIDATION.md
+++ b/tests/data/io/bbi/VALIDATION.md
@@ -8,7 +8,7 @@ predicate-pushdown fix ([datafusion-bio-formats#205], tag `v1.8.3`).
 
 | File | Needs pyBigWig | Covers |
 |------|----------------|--------|
-| `tests/test_io_bbi.py` | no | API, schema, autoSQL/rest, coordinate conversion, pushdown == client-side, register/SQL path |
+| `tests/test_io_bbi.py` | no | API, schema, autoSQL/rest, coordinate conversion, pushdown == client-side, register/SQL path, physical partition counts and exact serial/parallel equality for `target_partitions=1..8` |
 | `tests/test_io_bbi_streaming.py` | no | lazy scan, `limit` pushdown across batch boundaries, streaming vs in-memory engine equality, streaming aggregation, region pushdown unclipped |
 | `tests/test_io_bbi_parity.py` | yes (missing dependency skips; load errors fail) | row-for-row equality vs pyBigWig (bigWig intervals, bigBed `rest`), pushdown-region parity |
 

--- a/tests/test_io_bbi.py
+++ b/tests/test_io_bbi.py
@@ -216,6 +216,8 @@ def test_bbi_parallel_full_scan_matches_serial_without_duplicate_or_missing_rows
             expected_partitions = partitions
         else:
             actual = pb.read_bigbed(BIGBED, use_zero_based=True)
+            # annotations.bb has two independent indexed work units, so this
+            # small fixture correctly caps at two physical partitions.
             expected_partitions = min(partitions, 2)
 
     execution = _find_exec(plan, node_name)

--- a/tests/test_io_bbi.py
+++ b/tests/test_io_bbi.py
@@ -1,20 +1,82 @@
+from contextlib import contextmanager
 from pathlib import Path
 
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 
 import polars_bio as pb
 from polars_bio import get_metadata
+from polars_bio.context import ctx
 from polars_bio.polars_bio import (
     BigBedReadOptions,
     BigWigReadOptions,
     InputFormat,
     ReadOptions,
+    py_read_table,
+    py_register_table,
 )
 
 DATA_DIR = Path(__file__).parent / "data" / "io" / "bbi"
 BIGWIG = str(DATA_DIR / "signal.bw")
+LARGE_BIGWIG = str(DATA_DIR / "large_signal.bw")
 BIGBED = str(DATA_DIR / "annotations.bb")
+TARGET_PARTITIONS = "datafusion.execution.target_partitions"
+
+
+@contextmanager
+def _target_partitions(partitions: int):
+    original = pb.get_option(TARGET_PARTITIONS)
+    pb.set_option(TARGET_PARTITIONS, str(partitions))
+    try:
+        yield
+    finally:
+        pb.set_option(TARGET_PARTITIONS, original)
+
+
+def _find_exec(plan, node_name: str):
+    if plan.display().lstrip().startswith(f"{node_name}:"):
+        return plan
+    for child in plan.children():
+        result = _find_exec(child, node_name)
+        if result is not None:
+            return result
+    return None
+
+
+def _bbi_execution_plan(format_name: str, partitions: int):
+    if format_name == "bigwig":
+        path = LARGE_BIGWIG
+        input_format = InputFormat.BigWig
+        options = ReadOptions(bigwig_read_options=BigWigReadOptions(zero_based=True))
+    else:
+        path = BIGBED
+        input_format = InputFormat.BigBed
+        options = ReadOptions(
+            bigbed_read_options=BigBedReadOptions(zero_based=True, schema="auto")
+        )
+
+    table = py_register_table(
+        ctx,
+        path,
+        f"parallel_{format_name}_{partitions}",
+        input_format,
+        options,
+    )
+    return py_read_table(ctx, table.name).execution_plan()
+
+
+@pytest.fixture(scope="module")
+def serial_bbi_frames():
+    with _target_partitions(1):
+        return {
+            "bigwig": pb.read_bigwig(LARGE_BIGWIG, use_zero_based=True).sort(
+                ["chrom", "start", "end"]
+            ),
+            "bigbed": pb.read_bigbed(BIGBED, use_zero_based=True).sort(
+                ["chrom", "start", "end"]
+            ),
+        }
 
 
 def test_bigwig_bigbed_public_api_exports():
@@ -137,6 +199,30 @@ def test_scan_bigbed_projection_and_coordinate_conversion():
 
     assert df.columns == ["chrom", "start"]
     assert df.rows() == [("chr1", 1), ("chr1", 21), ("chr2", 6)]
+
+
+@pytest.mark.parametrize("partitions", range(1, 9), ids=lambda value: f"t{value}")
+@pytest.mark.parametrize(
+    ("format_name", "node_name"),
+    [("bigwig", "BigWigExec"), ("bigbed", "BigBedExec")],
+)
+def test_bbi_parallel_full_scan_matches_serial_without_duplicate_or_missing_rows(
+    serial_bbi_frames, format_name: str, node_name: str, partitions: int
+):
+    with _target_partitions(partitions):
+        plan = _bbi_execution_plan(format_name, partitions)
+        if format_name == "bigwig":
+            actual = pb.read_bigwig(LARGE_BIGWIG, use_zero_based=True)
+            expected_partitions = partitions
+        else:
+            actual = pb.read_bigbed(BIGBED, use_zero_based=True)
+            expected_partitions = min(partitions, 2)
+
+    execution = _find_exec(plan, node_name)
+    assert execution is not None, f"{node_name} node not found in execution plan"
+    assert execution.partition_count == expected_partitions
+    actual = actual.sort(["chrom", "start", "end"])
+    assert_frame_equal(actual, serial_bbi_frames[format_name])
 
 
 def test_register_bigwig_sql_path():


### PR DESCRIPTION
## Summary

- consume the released `datafusion-bio-formats` v1.11.0 tag (`80f3a6c`) containing the merged BBI parallel-scan work
- update all `datafusion-bio-functions` dependencies to the v0.18.0 release tag (`e937e49`)
- enable block-balanced parallel BigWig and BigBed scans through each file's built-in BBI cir-tree index
- document the capability and add downstream plan/correctness coverage for every `target_partitions` value from 1 through 8

All format crates resolve from one v1.11.0 source revision and all functions crates resolve from one v0.18.0 source revision. Both upstream releases still require DataFusion 53.0.0, so that compatibility pin remains unchanged.

## Correctness coverage

The new polars-bio test checks BigWig and BigBed at `t=1..8` and requires:

- the physical `BigWigExec`/`BigBedExec` partition count to match the available indexed work
- the complete sorted Polars DataFrame to equal the serial result exactly
- no rows introduced, duplicated, or lost at source-partition boundaries

The BigWig fixture contains 25,000 intervals and splits across all eight requested partitions. The small BigBed fixture correctly caps at its two indexed work units.

## Scalability evidence

The controlled five-process benchmark sweep is tracked in biodatageeks/bioformats-benchmark#5:

- BigWig all-column Arrow stream: 2.8304 s at `t=1` to 0.3835 s at `t=8` (**7.38x**)
- BigBed all-column Arrow stream: 0.0725 s at `t=1` to 0.0107 s at `t=8` (**6.79x**)
- all 320 fresh-process samples produced matching content fingerprints

## Verification

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets --all-features --locked` (9 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] full Python suite against rebuilt release extension: 1,353 passed, 2 skipped
- [x] `openspec validate add-bigwig-bigbed-support --strict`

Closes #443