### PR TITLE
build: pin bio formats to v1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,14 +1504,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "futures",
  "futures-util",
  "hex",
@@ -1530,27 +1530,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bbi"
-version = "1.9.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.10.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-trait",
  "bigtools",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "futures-util",
 ]
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "datafusion-execution",
  "env_logger",
  "futures",
@@ -1565,15 +1565,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bgen"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-stream",
  "async-trait",
  "blake3",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "libdeflater",
  "log",
@@ -1585,12 +1585,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cooler"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?branch=feat%2Fcooler#dbc62fb1b6b7ae7aa663002be188263802b43b1c"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?branch=feat%2Fcooler)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures-util",
  "hdf5-metno",
@@ -1600,31 +1600,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
-dependencies = [
- "async-compression",
- "bytes",
- "datafusion",
- "datafusion-execution",
- "futures",
- "log",
- "noodles-bgzf",
- "noodles-core",
- "noodles-sam",
- "opendal",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "datafusion-bio-format-core"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?branch=feat%2Fcooler#dbc62fb1b6b7ae7aa663002be188263802b43b1c"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1646,14 +1623,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "futures",
  "futures-util",
  "hex",
@@ -1672,8 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1681,7 +1658,7 @@ dependencies = [
  "bstr",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures",
  "futures-util",
@@ -1695,15 +1672,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures",
  "futures-util",
@@ -1719,15 +1696,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "env_logger",
  "flate2",
  "futures",
@@ -1746,15 +1723,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures",
  "futures-util",
@@ -1770,15 +1747,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures",
  "futures-util",
@@ -1797,14 +1774,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pgen"
-version = "0.3.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "0.4.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "flate2",
  "futures",
  "opendal",
@@ -1816,15 +1793,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "datafusion-execution",
  "env_logger",
  "flate2",
@@ -5022,7 +4999,7 @@ dependencies = [
  "datafusion-bio-format-bed",
  "datafusion-bio-format-bgen",
  "datafusion-bio-format-cooler",
- "datafusion-bio-format-core 1.11.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.11.0)",
+ "datafusion-bio-format-core",
  "datafusion-bio-format-cram",
  "datafusion-bio-format-fasta",
  "datafusion-bio-format-fastq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ pyo3-log = "0.13.3"
 
 
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats
-# v1.11.0 / datafusion-bio-functions v0.18.0, which pin datafusion to "=53.0.0".
+# v1.12.0 / datafusion-bio-functions v0.18.0, which pin datafusion to "=53.0.0".
 # Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
@@ -48,23 +48,20 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.11.0" }
-# cooler: branch dep until the crate ships in a tagged datafusion-bio-formats
-# release. RELEASE GATE: repoint to the tag (like the deps above) before any
-# polars-bio release — prepare-release checks must not pass with a branch ref.
-datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", branch = "feat/cooler" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.18.0" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.18.0", default-features = false }


### PR DESCRIPTION
## Summary

- pin every datafusion-bio-formats provider crate to the v1.12.0 release
- replace the temporary Cooler feature-branch dependency with the release tag
- collapse the duplicate datafusion-bio-formats-core dependency graph

PR #446 was merged before this release pin landed, so this is the clean follow-up from current master.

## Validation

- cargo fmt --all -- --check
- cargo check --locked --all-features
- cargo test --locked --lib: 16 passed
- cargo clippy --locked --all-targets --all-features -- -D warnings
- native-release, fresh-process benchmarks across FASTQ, BAM, VCF, BCF, BGEN, PGEN, BigWig, BigBed, COOL, and MCOOL
- correctness fingerprints and reference-reader equivalence passed for every specialized format

The benchmarked feature-branch tree and this clean follow-up tree have the same Git tree hash: c78733b69b2ed1c9ce8fa8fe934be6d1d68badc2.

Key regression checks:

- exact pre/post v1.12 BCF A/B: +0.8%, -1.5%, +1.2%, +1.7% at t=1,2,4,8
- final pre-release Cooler branch versus v1.12: v1.12 was faster in every tested COOL workload/thread cell
- FASTQ, BAM, VCF, BGEN, PGEN, BigWig, and BigBed remained consistent with the latest published/report baselines; observed cross-session variation is documented and no provider-level regression was detected
- COOL remained faster than cooler for full scans and collection, and for region queries from t=2 onward