### PR TITLE
chore: release 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-26
+
 ### Added
 
 - Cooler Hi-C contact matrix support (`.cool`/`.mcool`): `read_cool()`,
@@ -44,11 +46,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated `datafusion-bio-formats` to v1.11.0 and
+- Updated `datafusion-bio-formats` to v1.12.0 and
   `datafusion-bio-functions` to v0.18.0.
 - BigWig and BigBed full scans now use their built-in BBI index to balance
   compressed blocks across `datafusion.execution.target_partitions`. No sidecar
   index is required, and partitioned scans preserve every row exactly once.
+
+### Documentation
+
+- The README now shows the supported Python versions and wheel platforms, and
+  links directly to the Bioconda installation instructions (#441, #444).
+- The format capability matrix now correctly marks indexed GTF scans as parallel
+  and FASTQ reads as supporting projection pushdown (#442).
 
 ## [0.34.0] - 2026-08-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,7 +4987,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 
 [features]

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -145,7 +145,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.34.0"
+version = "0.35.0"
 description = "Blazing fast genomic operations on large Python dataframes"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "polars-bio"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "datafusion" },


### PR DESCRIPTION
Cuts the 0.35.0 release: version bumped in all three sources of truth plus both
lockfiles, and `[Unreleased]` closed into a dated `0.35.0` section.

## Highlights since 0.34.0

### Added

- **Cooler Hi-C contact matrices** — `read_cool()`, `scan_cool()`,
  `describe_cool()`, and `register_cool()` for `.cool` and `.mcool`, including
  multiresolution URIs, balancing weights, predicate/projection pushdown,
  parallel scans, wide coordinates and native count dtypes (#446)
- **Fast local Cooler scans** — direct HDF5 chunk reads allow decompression and
  unshuffling outside the global HDF5 lock; a 24.5M-pixel joined scan measured
  0.91 s serial and 0.27 s with four partitions (#446)

### Changed

- **Parallel BigWig and BigBed scans** — full scans use the built-in BBI index
  to balance compressed blocks across target partitions without a sidecar index
  (#445)
- Updated `datafusion-bio-formats` to v1.12.0 and
  `datafusion-bio-functions` to v0.18.0; all format providers now use tagged
  release dependencies (#445, #447)

### Fixed

- Typed integer and float literals emitted by the Polars optimizer now reach the
  predicate translator, restoring numeric reader-level pruning for every format
  while preserving client-side correctness fallback (#446)

### Documentation

- README adds the Bioconda install badge plus supported Python-version and wheel
  platform badges (#441, #444)
- The capability matrix now correctly marks indexed GTF scans as parallel and
  FASTQ reads as supporting projection pushdown (#442)

## Release readiness

| Check | Result |
|---|---|
| `Cargo.toml` / `pyproject.toml` / `polars_bio/__init__.py` | all `0.35.0`, no `0.34.0` stragglers |
| `cargo check` | exit 0 — `Checking polars_bio v0.35.0`, finished in 44.26s |
| `Cargo.lock` | `polars_bio` at `0.35.0` |
| `uv lock` | `polars-bio v0.34.0 -> v0.35.0` |
| `uv lock --check` | passes (CI's `linux_tests` gate) |
| Pre-commit hooks | AST, line endings, whitespace, case conflicts, isort and black pass |
| Release dependency gate | no branch dependencies remain in `Cargo.toml` |

The documentation entries from #441, #442 and #444 were missing from
`[Unreleased]` and are added as part of the cut. The dependency summary is also
updated from the intermediate v1.11.0 pin to the final v1.12.0 release pin from
#447.

Generated with [OpenAI Codex](https://openai.com/codex/).
