### PR TITLE
chore: release 0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-28
+
+### Fixed
+
+- Range operations returned wrong results on the **1-based** coordinate path,
+  which is the path used when DataFrames carry no coordinate-system metadata.
+  Fixed upstream in `datafusion-bio-functions` v0.19.1 and pulled in here
+  (#451; reported as #450).
+
+  - `coverage()` added one base per clamped edge, so a target identical to the
+    query, a target strictly containing it, and the query's own length were
+    three different numbers — a superset could report more covered bases than
+    the query spans.
+  - `subtract()` emitted half-open boundaries, keeping the first and last base
+    of every removed interval.
+  - `complement()` did the same for gap bounds, and reported a spurious
+    zero-length gap between intervals that are contiguous under 1-based
+    coordinates. It also clipped against an explicit `view_df` with half-open
+    comparisons, dropping an interval that ends exactly at the view start or
+    begins exactly at the view end.
+  - `nearest()` reported the distance between neighbours as one base too many.
+
+  0-based half-open results are unchanged throughout.
+
+- `count_overlaps()` and `nearest()` silently missed **0-based** intervals of
+  length 1 or less — a SNV or any point feature. `count_overlaps()` returned 0
+  and `nearest()` returned no match at all, while `overlap()` and `coverage()`
+  correctly reported the shared base on the same input (#451).
+
+### Changed
+
+- `subtract()` is roughly 20-25% faster on larger inputs.
+- Bumped `datafusion-bio-function-ranges`, `-pileup` and `-fastqc` from
+  v0.18.0 to v0.19.1.
+
+### Added
+
+- `tests/test_coordinate_system_semantics.py` covers every range operation on
+  both coordinate paths, against a reference that enumerates the base
+  positions an interval occupies rather than restating the implementation.
+  The 1-based path previously had no value-level coverage: the bioframe
+  comparison tests are pinned to 0-based because bioframe is 0-based, and the
+  partitioned-execution suites compare polars-bio against itself (#451).
+
 ## [0.35.0] - 2026-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,7 +4987,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polars_bio"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_bio"
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 
 [features]

--- a/polars_bio/__init__.py
+++ b/polars_bio/__init__.py
@@ -145,7 +145,7 @@ subtract = range_operations.subtract
 
 POLARS_BIO_MAX_THREADS = "datafusion.execution.target_partitions"
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"
 __all__ = [
     "ctx",
     "FilterOp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "polars-bio"
-version = "0.35.0"
+version = "0.35.1"
 description = "Blazing fast genomic operations on large Python dataframes"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -3121,7 +3121,7 @@ wheels = [
 
 [[package]]
 name = "polars-bio"
-version = "0.35.0"
+version = "0.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "datafusion" },


### PR DESCRIPTION
Patch release carrying the coordinate-system fixes from `datafusion-bio-functions` **v0.19.1** (#451, reported as #450).

## Fixed

Range operations returned wrong results on the **1-based** coordinate path — the path used whenever DataFrames carry no coordinate-system metadata, which is how the reporter hit it.

- **`coverage()`** added one base per clamped edge, so a target identical to the query, a target strictly containing it, and the query's own length came out as three different numbers. A superset could report more covered bases than the query spans.
- **`subtract()`** emitted half-open boundaries, keeping the first and last base of every removed interval.
- **`complement()`** did the same for gap bounds, reported a spurious zero-length gap between intervals that are contiguous under 1-based coordinates, and clipped against an explicit `view_df` with half-open comparisons — dropping an interval that ends exactly at the view start or begins exactly at the view end.
- **`nearest()`** reported the distance between neighbours as one base too many.

Separately, **`count_overlaps()` and `nearest()` silently missed 0-based intervals of length ≤ 1** — a SNV or any point feature. `count_overlaps()` returned 0 and `nearest()` found no match at all, while `overlap()` and `coverage()` correctly reported the shared base on the same input.

**0-based half-open results are unchanged throughout**, confirmed by byte-identical row counts across every operation and test case in the benchmark A/B.

## Changed

- `subtract()` is roughly **20–25% faster** on larger inputs.
- `datafusion-bio-function-ranges`, `-pileup` and `-fastqc` bumped v0.18.0 → v0.19.1.

## Added

- `tests/test_coordinate_system_semantics.py` — every range operation on both coordinate paths, checked against a reference that enumerates the base positions an interval occupies rather than restating the implementation. The 1-based path previously had no value-level coverage at all: the bioframe comparison tests are pinned to 0-based because bioframe is 0-based, and the partitioned-execution suites compare polars-bio against itself.

## Release readiness

| Check | Result |
|---|---|
| Version in `Cargo.toml`, `pyproject.toml`, `polars_bio/__init__.py` | ✅ all `0.35.1`, no `0.35.0` stragglers |
| `cargo check` | ✅ clean; `Cargo.lock` shows `polars_bio 0.35.1` |
| `uv lock` / `uv lock --check` | ✅ regenerated, `polars-bio 0.35.1`, check passes |
| `CHANGELOG.md` | ✅ `[0.35.1] - 2026-08-28` cut, fresh `[Unreleased]` above |
| Test suite | ✅ 1462 + 37 passing against the released v0.19.1 tag |
| Performance | ✅ no regression on either coordinate path (medians −1.0% / −0.9%) — [polars-bio-bench#33](https://github.com/biodatageeks/polars-bio-bench/pull/33) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
