### PR TITLE
feat(pgen): open production PLINK 2 filesets; expose companion caps (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PGEN entry points (`read_pgen`, `scan_pgen`, `read_pgen_matrix`,
+  `describe_pgen`, `register_pgen`) accept `max_companion_bytes`,
+  `max_decompressed_companion_bytes`, and `max_variants`, forwarded to the
+  provider like the existing range controls (#453).
+
+### Changed
+
+- PGEN companions are streamed and parsed into a columnar variant table
+  upstream (`datafusion-bio-formats`), so production PLINK 2 filesets open
+  without tuning: the PGS Catalog 1000 Genomes GRCh38 panel (75.2M variants,
+  541 MiB `.pvar.zst`) opens in about 4 s within about 4 GB, where the
+  previous per-row representation would have needed ~45 GB. Provider defaults
+  rose to 4 GiB / 16 GiB / 250M variants.
+- `read_pgen_matrix` fills its `positions` array from Rust instead of building
+  a Python list of one integer per variant first.
+
+### Fixed
+
+- `describe_pgen`, `scan_pgen`, `read_pgen`, and `read_pgen_matrix` rejected
+  the published 1000 Genomes PLINK 2 fileset because its `.pvar.zst` exceeded
+  a hard 512 MiB companion cap that no entry point could raise (#453). The
+  limit errors now name the argument to change.
+
 ## [0.35.1] - 2026-08-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
  "enum-map",
  "fxhash",
  "getset",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "itertools-num",
  "multimap",
  "ndarray 0.16.1",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bbi"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bgen"
 version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cooler"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pgen"
 version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.0#6457fbc07f511c171580038a60b899e8f64db1e1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -5145,7 +5145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2 1.0.106",
  "quote 1.0.46",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,8 @@ pyo3-log = "0.13.3"
 # v1.12.0 / datafusion-bio-functions v0.19.1, which pin datafusion to "=53.0.0".
 # Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
 # datafusion-bio-formats is pinned to the master commit carrying PR #247 (PGEN
-# companion streaming, polars-bio #453); switch back to a release tag once one is cut.
+# companion streaming, polars-bio #453). The release-tag transition is tracked
+# in https://github.com/biodatageeks/polars-bio/issues/457.
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
 arrow-schema = "58.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ pyo3-log = "0.13.3"
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats
 # v1.12.0 / datafusion-bio-functions v0.19.1, which pin datafusion to "=53.0.0".
 # Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
+# datafusion-bio-formats is pinned to the master commit carrying PR #247 (PGEN
+# companion streaming, polars-bio #453); switch back to a release tag once one is cut.
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
 arrow-schema = "58.3.0"
@@ -48,20 +50,20 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
-datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.0" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1", default-features = false }

--- a/docs/features/reading.md
+++ b/docs/features/reading.md
@@ -411,6 +411,15 @@ value per sample have no dense form.
   default.
 - **Projection** — a scan that selects only metadata columns never reads
   genotype records.
+- **Companion limits** — the `.pvar` and `.psam` are streamed and parsed into
+  a compact variant table when the fileset opens, so a panel of tens of
+  millions of variants costs a few tens of bytes per variant in memory: the
+  published 1000 Genomes reference panel (75M variants) opens in a few
+  seconds within about 4 GB. `max_companion_bytes` (4 GiB),
+  `max_decompressed_companion_bytes` (16 GiB), and `max_variants` (250
+  million) are sanity bounds on that load, accepted by every PGEN entry
+  point including `describe_pgen` and `register_pgen`; a fileset over one of
+  them fails before any genotype is read, naming the argument to raise.
 
 ```python
 import polars_bio as pb

--- a/openspec/changes/add-pgen-companion-sidecar-cache/proposal.md
+++ b/openspec/changes/add-pgen-companion-sidecar-cache/proposal.md
@@ -1,0 +1,23 @@
+# Change: Expose the parsed PVAR sidecar cache
+
+## Why
+
+After `refactor-pgen-companion-memory-model` every `scan_pgen`,
+`describe_pgen`, `register_pgen`, and `read_pgen_matrix` call re-parses the
+PVAR (~5 s and ~4.5 GB resident on the PGS Catalog 1000 Genomes panel).
+Upstream adds a memory-mappable sidecar under the same change id; polars-bio
+needs to let callers choose the cache mode and location.
+
+## What Changes
+
+- Add `companion_cache` (`"off"`, `"read_only"`, `"read_write"`; default
+  `"read_only"`) and `cache_dir` to `PgenReadOptions` and to every PGEN entry
+  point, forwarded like the companion caps.
+- Document the sidecar, its key, and the memory effect in `reading.md`.
+
+## Impact
+
+- Affected specs: `pgen`.
+- Affected code: `src/option.rs`, `src/scan.rs`, `polars_bio/io.py`,
+  `polars_bio/sql.py`, `docs/features/reading.md`, `tests/test_pgen_io.py`.
+- Depends on the upstream release carrying `add-pgen-companion-sidecar-cache`.

--- a/openspec/changes/add-pgen-companion-sidecar-cache/specs/pgen/spec.md
+++ b/openspec/changes/add-pgen-companion-sidecar-cache/specs/pgen/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: PGEN Companion Cache Controls
+
+Every PGEN entry point SHALL accept a companion cache mode and an optional
+cache directory and forward them to the provider, defaulting to read-only use
+of an existing sidecar.
+
+#### Scenario: Read-write mode creates the sidecar
+- **WHEN** a fileset is read with `companion_cache="read_write"`
+- **THEN** a sidecar is written next to the PVAR or in `cache_dir`
+- **AND** a later read of the same fileset opens without parsing the PVAR.
+
+#### Scenario: Off mode
+- **WHEN** `companion_cache="off"` is given
+- **THEN** no sidecar is read or written.
+
+#### Scenario: Invalid mode
+- **WHEN** an unknown cache mode is given
+- **THEN** the call raises naming the accepted values.

--- a/openspec/changes/add-pgen-companion-sidecar-cache/tasks.md
+++ b/openspec/changes/add-pgen-companion-sidecar-cache/tasks.md
@@ -1,0 +1,8 @@
+## 1. Plumbing
+- [ ] 1.1 `companion_cache` and `cache_dir` on `PgenReadOptions` and `native_pgen_options`; unknown mode is a `ValueError` naming the accepted values.
+- [ ] 1.2 Arguments on `read_pgen`, `scan_pgen`, `read_pgen_matrix`, `describe_pgen`, `register_pgen`.
+
+## 2. Docs and tests
+- [ ] 2.1 `reading.md` section and CHANGELOG entry.
+- [ ] 2.2 Forwarding tests; `read_write` on a `tmp_path` copy of the oracle creates the sidecar and a second read uses it; `off` creates nothing.
+- [ ] 2.3 Real-panel check: second `describe_pgen` under a second with the sidecar present.

--- a/openspec/changes/add-pgen-matrix-variant-selection/proposal.md
+++ b/openspec/changes/add-pgen-matrix-variant-selection/proposal.md
@@ -1,0 +1,30 @@
+# Change: Variant selection for `read_pgen_matrix`
+
+## Why
+
+`read_pgen_matrix` decodes every variant in the fileset. On the PGS Catalog
+1000 Genomes panel (75.2M variants, 3,202 samples) the dense output is
+224 GiB for `ALT_COUNT` and 896 GiB for `DS`, so after the companion cap is
+lifted (`refactor-pgen-companion-memory-model`, #453) the call still cannot
+complete. Scoring needs the rows that match a score file or a region, and
+callers who want to stream need a way to take the matrix in row windows.
+
+## What Changes
+
+- `read_pgen_matrix` gains `region="chrom:start-end"` (or `chrom` alone) and
+  `rows=` (a `slice`/`range` or a sorted integer array of PVAR row indices).
+  At most one of the two may be given. Shape, `positions`, and
+  `sample_names` follow the selection.
+- Row windows are the caller's loop over `rows=range(...)`; documented in
+  `reading.md` with a chunked-scoring example.
+- Mirrors the upstream change of the same id, which adds the selection to the
+  matrix reader and a region-to-rows lookup on the variant table.
+
+## Impact
+
+- Affected specs: `pgen` (Dense PGEN Genotype Matrix gains a selection
+  clause).
+- Affected code: `polars_bio/io.py` (`read_pgen_matrix`), `src/lib.rs`
+  (`PyPgenMatrixReader`), `src/scan.rs` (`OpenPgenMatrix`),
+  `docs/features/reading.md`, `tests/test_pgen_io.py`.
+- Depends on the upstream release carrying `add-pgen-matrix-variant-selection`.

--- a/openspec/changes/add-pgen-matrix-variant-selection/specs/pgen/spec.md
+++ b/openspec/changes/add-pgen-matrix-variant-selection/specs/pgen/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: PGEN Matrix Variant Selection
+
+`read_pgen_matrix` SHALL decode only the variants a caller selects by region
+or by PVAR row indices, and SHALL size its output, positions, and sample names
+by that selection.
+
+#### Scenario: Region selection
+- **WHEN** `region="chr22:16000000-17000000"` is given
+- **THEN** the matrix holds exactly the rows whose start lies in that range, in
+  PVAR order, and equals the same rows of a full read.
+
+#### Scenario: Row-range windows
+- **WHEN** a caller loops over `rows=range(a, b)` windows covering the fileset
+- **THEN** concatenating the windows reproduces the full matrix.
+
+#### Scenario: Conflicting or invalid selection
+- **WHEN** both `region` and `rows` are given, or `rows` is unsorted or out of
+  range
+- **THEN** the call raises before any genotype record is read.

--- a/openspec/changes/add-pgen-matrix-variant-selection/tasks.md
+++ b/openspec/changes/add-pgen-matrix-variant-selection/tasks.md
@@ -1,0 +1,11 @@
+## 1. Binding
+- [ ] 1.1 `PyPgenMatrixReader` accepts an optional selection (index range or `int64` NumPy array) and a `row_range(chrom, start, end)` lookup; `shape`, `positions_into`, and `read_into` follow it.
+
+## 2. Python API
+- [ ] 2.1 Add `region` and `rows` to `read_pgen_matrix`; parse `chrom:start-end` in the configured coordinate system; reject both at once and unsorted or out-of-range `rows`.
+- [ ] 2.2 Document in `reading.md` with a chunked example; CHANGELOG entry.
+
+## 3. Tests
+- [ ] 3.1 `region` and `rows` selections equal the corresponding slice of the full matrix on the oracle fixtures; empty region gives a `(0, samples)` matrix.
+- [ ] 3.2 Windowed loop over `rows=range(...)` reassembles the full matrix.
+- [ ] 3.3 Real-panel check: a chr22 region of `GRCh38_1000G_ALL.pgen` matches `pgenlib` ALT counts.

--- a/openspec/changes/refactor-pgen-companion-memory-model/design.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The size gate lives in the upstream provider's `PgenReadOptions` defaults
+(`max_companion_bytes` 512 MiB, `max_decompressed_companion_bytes` 1 GiB,
+`max_variants` 100M, `max_samples` 10M). polars-bio's `native_pgen_options`
+(src/scan.rs:534) forwards only `max_range_gap`, `max_range_bytes`, and
+`batch_soft_byte_limit` and takes the rest from `Default`. The caps guard an
+eager materialization whose measured cost is 5–10× the decoded PVAR text, so
+the memory model has to change before the caps can move. That work is
+upstream; this change carries the API surface and the dependency bump. See
+the upstream `design.md` under the same change id for the streaming and
+columnar-table decisions.
+
+## Goals / Non-Goals
+
+- Goals: the published 1000G panels open with default arguments; every PGEN
+  entry point can raise or lower the companion caps; a limit error tells the
+  caller which argument to change.
+- Non-Goals: caching parsed companions across calls; changing the PGEN
+  schema; exposing `max_samples`, `max_header_bytes`, or `max_record_bytes`,
+  which no reported fileset approaches.
+
+## Decisions
+
+- **Decision: expose three caps, not all six.** `max_companion_bytes`,
+  `max_decompressed_companion_bytes`, and `max_variants` are the ones a real
+  fileset can hit; the others are header and record sanity bounds. They follow
+  the existing pattern: `Optional[int]`, `None` keeps the provider default,
+  forwarded through `PgenReadOptions` and `native_pgen_options` with
+  `unwrap_or(defaults.x)`.
+- **Decision: `describe_pgen` gets the caps too.** It opens the fileset like
+  a scan and was the first call in the report to fail, so it must accept the
+  same controls as the other entry points, as `pgi_path` already does.
+- **Decision: matrix positions cross the boundary as a NumPy array.**
+  `PyPgenMatrixReader::positions` returns `Vec<u64>`, which PyO3 converts to
+  a `list` of Python integers (~36 B each) before `np.asarray` copies it
+  again. It will fill a caller-allocated `int64` array through the same
+  buffer path `read_into` already uses, so the transfer costs 8 B per row
+  and no Python objects. `PgenMatrix.positions` keeps its dtype and shape.
+- **Decision: tests assert forwarding and the error, not the panel.** The
+  panel is 9 GiB and cannot be a fixture. Tests use `_captured_pgen_options`
+  to prove the values reach the options object, lower a cap below the oracle
+  fixture's size to prove the error names the argument, and confirm a raised
+  cap does not change content. The real-panel run is recorded in the change
+  tasks and the PR, not in CI.
+
+## Risks / Trade-offs
+
+- The fix depends on an upstream release; until the tag lands, polars-bio
+  verifies through a local `[patch]` that must not be committed.
+- `read_pgen_matrix` still has no variant selection, so the full panel's
+  dense output (224 GiB int8, 896 GiB float32) cannot be requested; that is
+  the separate change `add-pgen-matrix-variant-selection`. Repeated opens
+  re-parse the companion; that is `add-pgen-companion-sidecar-cache`.
+- Resident memory on the full panel is still ~4.5–5 GB for the variant table
+  at 75–85M rows; documented in `reading.md` alongside the caps.
+
+## Migration Plan
+
+Additive keyword arguments and a dependency bump; minor release. No caller
+changes required.

--- a/openspec/changes/refactor-pgen-companion-memory-model/design.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/design.md
@@ -13,7 +13,8 @@ columnar-table decisions.
 
 ## Goals / Non-Goals
 
-- Goals: the published 1000G panels open with default arguments; every PGEN
+- Goals: the published 1000G panels open for metadata inspection and scans
+  with default arguments; every PGEN
   entry point can raise or lower the companion caps; a limit error tells the
   caller which argument to change.
 - Non-Goals: caching parsed companions across calls; changing the PGEN
@@ -46,8 +47,9 @@ columnar-table decisions.
 
 ## Risks / Trade-offs
 
-- The fix depends on an upstream release; until the tag lands, polars-bio
-  verifies through a local `[patch]` that must not be committed.
+- The fix depends on upstream PR #247. All format crates are pinned to its
+  exact published revision until a release tag lands (tracked in #457);
+  no local `[patch]` paths are part of the published dependency configuration.
 - `read_pgen_matrix` still has no variant selection, so the full panel's
   dense output (224 GiB int8, 896 GiB float32) cannot be requested; that is
   the separate change `add-pgen-matrix-variant-selection`. Repeated opens

--- a/openspec/changes/refactor-pgen-companion-memory-model/proposal.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/proposal.md
@@ -1,0 +1,43 @@
+# Change: Open production PLINK 2 filesets by fixing the PGEN companion memory model
+
+## Why
+
+`describe_pgen`, `scan_pgen`, `read_pgen`, and `read_pgen_matrix` refuse the
+published PGS Catalog 1000 Genomes panel (`pgsc_1000G_v1`, #453): its
+`.pvar.zst` is 541–592 MiB against a 512 MiB provider cap, decodes to
+2.3–2.5 GiB against a 1 GiB cap, holds 75.2M (GRCh38) and 84.8M (GRCh37)
+variants against a 100M cap, and no polars-bio entry point exposes any of
+those options. Raising the caps alone is not a fix: the provider holds the compressed
+bytes, the decoded text, and six heap objects per variant at once, which
+measures at ~600 B per variant on a chr22 slice of the same panel, or ~45 GB
+to describe and ~85 GB to scan the full panel.
+
+## What Changes
+
+- Upstream (datafusion-bio-formats, mirrored change of the same id): stream
+  the companion decode in bounded blocks, store variants in a columnar table
+  at a pinned per-variant cost, raise the companion and variant-count defaults so
+  the standard panels open untuned, and name the option in every limit error.
+- polars-bio: expose `max_companion_bytes`, `max_decompressed_companion_bytes`,
+  and `max_variants` on `PgenReadOptions` and on `read_pgen`, `scan_pgen`,
+  `read_pgen_matrix`, `describe_pgen`, and `register_pgen`, forwarded like the
+  existing range controls and defaulting to the provider values.
+- Return `read_pgen_matrix` row positions as a NumPy array built in Rust
+  instead of a Python list of integers; on the 75M-variant panel the list
+  costs ~2.7 GB before NumPy sees it.
+- Bump the `datafusion-bio-format-*` tag to the release carrying the
+  upstream change; document the caps in `docs/features/reading.md` and the
+  changelog.
+- Verify on the real `GRCh38_1000G_ALL` trio: open time, peak RSS, and ALT
+  count parity with `pgenlib` on a region.
+
+## Impact
+
+- Affected specs: `pgen` (PGEN Companion Discovery, PGEN Read Coalescing
+  Control gain companion-limit requirements).
+- Affected code: `src/option.rs` (`PgenReadOptions`), `src/scan.rs`
+  (`native_pgen_options`), `src/lib.rs` (`PyPgenMatrixReader::positions`), `polars_bio/io.py`, `polars_bio/sql.py`,
+  `docs/features/reading.md`, `tests/test_pgen_io.py`, `Cargo.toml`,
+  `CHANGELOG.md`.
+- No schema or coordinate change. Existing calls behave the same except that
+  filesets previously rejected by size now open.

--- a/openspec/changes/refactor-pgen-companion-memory-model/proposal.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/proposal.md
@@ -25,9 +25,10 @@ to describe and ~85 GB to scan the full panel.
 - Return `read_pgen_matrix` row positions as a NumPy array built in Rust
   instead of a Python list of integers; on the 75M-variant panel the list
   costs ~2.7 GB before NumPy sees it.
-- Bump the `datafusion-bio-format-*` tag to the release carrying the
-  upstream change; document the caps in `docs/features/reading.md` and the
-  changelog.
+- Pin every `datafusion-bio-format-*` crate to the exact upstream revision
+  carrying the change until a release is available; the release-tag transition
+  remains open in polars-bio #457. Document the caps in
+  `docs/features/reading.md` and the changelog.
 - Verify on the real `GRCh38_1000G_ALL` trio: open time, peak RSS, and ALT
   count parity with `pgenlib` on a region.
 

--- a/openspec/changes/refactor-pgen-companion-memory-model/specs/pgen/spec.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/specs/pgen/spec.md
@@ -6,10 +6,15 @@ The system SHALL let a caller raise or lower the PVAR and PSAM companion caps
 at every PGEN entry point, and SHALL default them to provider values that open
 the published PLINK 2 reference panels.
 
-#### Scenario: Reference panel opens untuned
-- **WHEN** `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen` is described, scanned, read,
-  or read as a matrix with no cap arguments
-- **THEN** the fileset opens and its variant count matches the PGEN header.
+#### Scenario: Reference panel metadata opens untuned
+- **WHEN** `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen` is described with
+  `describe_pgen` and scanned with only metadata columns, with no cap arguments
+- **THEN** describing the fileset returns its schema and file properties
+- **AND** the metadata scan's row count matches the PGEN header's variant count.
+
+This scenario does not require materializing a full-panel dense genotype
+matrix. Its output alone needs about 224 GiB for `ALT_COUNT`; row selection
+remains the separate `add-pgen-matrix-variant-selection` change.
 
 #### Scenario: Caps are accepted at every entry point
 - **WHEN** `max_companion_bytes`, `max_decompressed_companion_bytes`, or

--- a/openspec/changes/refactor-pgen-companion-memory-model/specs/pgen/spec.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/specs/pgen/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: PGEN Companion Limit Controls
+
+The system SHALL let a caller raise or lower the PVAR and PSAM companion caps
+at every PGEN entry point, and SHALL default them to provider values that open
+the published PLINK 2 reference panels.
+
+#### Scenario: Reference panel opens untuned
+- **WHEN** `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen` is described, scanned, read,
+  or read as a matrix with no cap arguments
+- **THEN** the fileset opens and its variant count matches the PGEN header.
+
+#### Scenario: Caps are accepted at every entry point
+- **WHEN** `max_companion_bytes`, `max_decompressed_companion_bytes`, or
+  `max_variants` is passed to `read_pgen`, `scan_pgen`, `read_pgen_matrix`,
+  `describe_pgen`, or `register_pgen`
+- **THEN** the value reaches the provider options
+- **AND** an unset value keeps the provider default rather than zero.
+
+#### Scenario: A lowered cap fails by name
+- **WHEN** a cap is set below the fileset's size
+- **THEN** the call raises before any genotype record is read
+- **AND** the message names the argument and the configured value.
+
+#### Scenario: Matrix positions avoid Python objects
+- **WHEN** `read_pgen_matrix` reports row positions
+- **THEN** they are delivered as an `int64` NumPy array filled from Rust
+- **AND** no intermediate Python list of integers is built.
+
+#### Scenario: A raised cap does not change content
+- **WHEN** the same fileset is read with a cap raised above the default
+- **THEN** the emitted rows and genotypes are identical to the default read.

--- a/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
@@ -1,6 +1,7 @@
 ## 1. Upstream dependency
-- [x] 1.1 Land `refactor-pgen-companion-memory-model` in datafusion-bio-formats and cut a release tag.
-- [x] 1.2 Bump every `datafusion-bio-format-*` tag in `Cargo.toml` and regenerate `Cargo.lock`.
+- [x] 1.1 Land `refactor-pgen-companion-memory-model` in datafusion-bio-formats (upstream PR #247, commit `1c86f0c`).
+- [x] 1.2 Pin every `datafusion-bio-format-*` crate in `Cargo.toml` to that exact revision and regenerate `Cargo.lock`.
+- [ ] 1.3 Cut an upstream release containing the fix, replace all revision pins with its tag, regenerate the lockfile and rerun integration checks (tracked by polars-bio #457).
 
 ## 2. Options plumbing
 - [x] 2.1 Add `max_companion_bytes`, `max_decompressed_companion_bytes`, `max_variants` (`Option<usize>`) to `PgenReadOptions` in `src/option.rs` (fields, constructor signature, `default()`).

--- a/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
@@ -1,0 +1,23 @@
+## 1. Upstream dependency
+- [ ] 1.1 Land `refactor-pgen-companion-memory-model` in datafusion-bio-formats and cut a release tag.
+- [ ] 1.2 Bump every `datafusion-bio-format-*` tag in `Cargo.toml` and regenerate `Cargo.lock`.
+
+## 2. Options plumbing
+- [x] 2.1 Add `max_companion_bytes`, `max_decompressed_companion_bytes`, `max_variants` (`Option<usize>`) to `PgenReadOptions` in `src/option.rs` (fields, constructor signature, `default()`).
+- [x] 2.2 Forward them in `native_pgen_options` (`src/scan.rs`) with `unwrap_or(defaults.x)`.
+- [x] 2.3 Replace `PyPgenMatrixReader::positions` with `positions_into(destination: int64 NumPy array)` and have `read_pgen_matrix` allocate the array; drop the list round trip.
+
+## 3. Python entry points
+- [x] 3.1 Add the three keyword arguments, documented in the same style as `max_range_bytes`, to `read_pgen`, `scan_pgen`, `read_pgen_matrix`, `describe_pgen` in `polars_bio/io.py` and `register_pgen` in `polars_bio/sql.py`.
+- [x] 3.2 Document the caps and the panel-scale memory expectation in `docs/features/reading.md`; add a CHANGELOG entry referencing #453.
+
+## 4. Tests
+- [x] 4.1 Forwarding test through `_captured_pgen_options` for each entry point.
+- [x] 4.2 A cap lowered below the oracle fixture raises an error naming the argument; a raised cap leaves content identical to the default read.
+- [x] 4.3a Positions test: `PgenMatrix.positions` is `int64`, one per row, equal to the scan's `start` column, and the reader exposes no list-returning positions method.
+- [x] 4.3 Full `tests/test_pgen_io.py` green; `cargo clippy` and `cargo fmt` clean.
+
+## 5. Real-panel verification
+- [x] 5.1 `describe_pgen`, metadata scan, and `read_pgen_matrix(field="ALT_COUNT")` on a region of `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen`; record open time and peak RSS.
+- [x] 5.2 ALT-count parity with `pgenlib` on that region; GRCh37 companions open as well.
+- [ ] 5.3 Report the numbers on #453 and in the PR.

--- a/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
@@ -19,6 +19,6 @@
 - [x] 4.3 Full `tests/test_pgen_io.py` green; `cargo clippy` and `cargo fmt` clean.
 
 ## 5. Real-panel verification
-- [x] 5.1 `describe_pgen`, metadata scan, and `read_pgen_matrix(field="ALT_COUNT")` on a region of `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen`; record open time and peak RSS.
+- [x] 5.1 `describe_pgen` and a full metadata scan of `pgsc_1000G_v1/GRCh38_1000G_ALL.pgen`, plus an ALT-count scan on chr22:16.0–16.1M; record open time and peak RSS. Full-panel dense matrix materialization is not claimed.
 - [x] 5.2 ALT-count parity with `pgenlib` on that region; GRCh37 companions open as well.
-- [ ] 5.3 Report the numbers on #453 and in the PR.
+- [x] 5.3 Report the numbers in PR #454 and [on #453](https://github.com/biodatageeks/polars-bio/issues/453#issuecomment-5551736143).

--- a/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
+++ b/openspec/changes/refactor-pgen-companion-memory-model/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Upstream dependency
-- [ ] 1.1 Land `refactor-pgen-companion-memory-model` in datafusion-bio-formats and cut a release tag.
-- [ ] 1.2 Bump every `datafusion-bio-format-*` tag in `Cargo.toml` and regenerate `Cargo.lock`.
+- [x] 1.1 Land `refactor-pgen-companion-memory-model` in datafusion-bio-formats and cut a release tag.
+- [x] 1.2 Bump every `datafusion-bio-format-*` tag in `Cargo.toml` and regenerate `Cargo.lock`.
 
 ## 2. Options plumbing
 - [x] 2.1 Add `max_companion_bytes`, `max_decompressed_companion_bytes`, `max_variants` (`Option<usize>`) to `PgenReadOptions` in `src/option.rs` (fields, constructor signature, `default()`).

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2193,6 +2193,9 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2222,6 +2225,9 @@ class IOOperations:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads, in bytes. The provider default is 0, which never bridges a gap and issues one read per contiguous run of selected variants. Raising it trades wasted bytes for fewer requests, which matters most on object storage. If *None*, the provider default is used.
             max_range_bytes: The largest coalesced read, in bytes. If *None*, the provider default is used.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch. If *None*, the provider default is used.
+            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
+            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
+            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -2248,6 +2254,9 @@ class IOOperations:
             max_range_gap=max_range_gap,
             max_range_bytes=max_range_bytes,
             batch_soft_byte_limit=batch_soft_byte_limit,
+            max_companion_bytes=max_companion_bytes,
+            max_decompressed_companion_bytes=max_decompressed_companion_bytes,
+            max_variants=max_variants,
             chunk_size=chunk_size,
             concurrent_fetches=concurrent_fetches,
             allow_anonymous=allow_anonymous,
@@ -2278,6 +2287,9 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2323,6 +2335,9 @@ class IOOperations:
             max_range_gap=max_range_gap,
             max_range_bytes=max_range_bytes,
             batch_soft_byte_limit=batch_soft_byte_limit,
+            max_companion_bytes=max_companion_bytes,
+            max_decompressed_companion_bytes=max_decompressed_companion_bytes,
+            max_variants=max_variants,
         )
         read_options = ReadOptions(pgen_read_options=pgen_read_options)
         return _read_file(
@@ -2348,6 +2363,9 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2481,6 +2499,9 @@ class IOOperations:
             max_range_gap=max_range_gap,
             max_range_bytes=max_range_bytes,
             batch_soft_byte_limit=batch_soft_byte_limit,
+            max_companion_bytes=max_companion_bytes,
+            max_decompressed_companion_bytes=max_decompressed_companion_bytes,
+            max_variants=max_variants,
         )
 
         from polars_bio.context import get_option
@@ -2502,11 +2523,10 @@ class IOOperations:
         # the only place a caller cannot route around.
         reader.read_into(field, values, copy_threads, float(missing))
 
-        positions = np.asarray(reader.positions(), dtype=np.int64)
-        if positions.shape[0] != variants:
-            raise RuntimeError(
-                f"PGEN reported {variants} variants but {positions.shape[0]} positions"
-            )
+        # Filled in place for the same reason as `values`: a list of Python
+        # integers for a panel-scale fileset would cost gigabytes on its own.
+        positions = np.empty(variants, dtype=np.int64)
+        reader.positions_into(positions)
         return PgenMatrix(
             values=values, positions=positions, sample_names=list(reader.sample_names())
         )
@@ -3276,6 +3296,9 @@ class IOOperations:
         pvar_path: Union[str, None] = None,
         psam_path: Union[str, None] = None,
         pgi_path: Union[str, None] = None,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
     ) -> pl.DataFrame:
         """
         Describe the schema a PLINK 2 PGEN fileset produces.
@@ -3294,6 +3317,9 @@ class IOOperations:
             pvar_path: An explicit `.pvar` companion.
             psam_path: An explicit `.psam` companion.
             pgi_path: An explicit `.pgi` index, for a PGEN that uses an external index. Without it, such a fileset cannot be opened here at all.
+            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
+            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
+            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
 
         !!! note
             The reported schema is the one the default `genotype_fields=("GT",)`
@@ -3316,6 +3342,9 @@ class IOOperations:
             pvar_path=pvar_path,
             psam_path=psam_path,
             pgi_path=pgi_path,
+            max_companion_bytes=max_companion_bytes,
+            max_decompressed_companion_bytes=max_decompressed_companion_bytes,
+            max_variants=max_variants,
             zero_based=_resolve_zero_based(None),
         )
         # Registering under the derived name would deregister and replace a

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2226,9 +2226,6 @@ class IOOperations:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads, in bytes. The provider default is 0, which never bridges a gap and issues one read per contiguous run of selected variants. Raising it trades wasted bytes for fewer requests, which matters most on object storage. If *None*, the provider default is used.
             max_range_bytes: The largest coalesced read, in bytes. If *None*, the provider default is used.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch. If *None*, the provider default is used.
-            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
-            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
-            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -2239,6 +2236,9 @@ class IOOperations:
             projection_pushdown: Enable column projection pushdown. Metadata-only scans do not read genotype records.
             predicate_pushdown: Push `chrom`, `id`, `start`, and `end` predicates into variant selection.
             use_zero_based: If True, output 0-based half-open coordinates. If False, output 1-based closed coordinates. If None (default), uses the global configuration.
+            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
+            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
+            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
 
         !!! note
             PGEN is input-only.
@@ -2413,9 +2413,6 @@ class IOOperations:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads.
             max_range_bytes: The largest coalesced read, in bytes.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch.
-            max_companion_bytes: Maximum on-disk companion size in bytes. None uses the provider default (4 GiB).
-            max_decompressed_companion_bytes: Maximum decoded companion size in bytes. None uses the provider default (16 GiB).
-            max_variants: Maximum PVAR row count. None uses the provider default (250 million).
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -2425,6 +2422,9 @@ class IOOperations:
             compression_type: The compression override.
             use_zero_based: If True, report 0-based positions. If False, 1-based. If None (default), uses the global configuration.
             copy_threads: How many threads decode into the result. They write disjoint row ranges, so they never contend. If *None* (default), this follows `datafusion.execution.target_partitions`, so a single-partition read stays single-threaded end to end.
+            max_companion_bytes: Maximum on-disk companion size in bytes. None uses the provider default (4 GiB).
+            max_decompressed_companion_bytes: Maximum decoded companion size in bytes. None uses the provider default (16 GiB).
+            max_variants: Maximum PVAR row count. None uses the provider default (250 million).
 
         Returns:
             A `PgenMatrix` of `values` (a C-contiguous `(variants, samples)`

--- a/polars_bio/io.py
+++ b/polars_bio/io.py
@@ -2193,9 +2193,6 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
-        max_companion_bytes: Union[int, None] = None,
-        max_decompressed_companion_bytes: Union[int, None] = None,
-        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2206,6 +2203,10 @@ class IOOperations:
         projection_pushdown: bool = True,
         predicate_pushdown: bool = True,
         use_zero_based: Optional[bool] = None,
+        *,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
     ) -> pl.DataFrame:
         """
         Read a PLINK 2 PGEN fileset into a DataFrame.
@@ -2287,9 +2288,6 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
-        max_companion_bytes: Union[int, None] = None,
-        max_decompressed_companion_bytes: Union[int, None] = None,
-        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2300,12 +2298,21 @@ class IOOperations:
         projection_pushdown: bool = True,
         predicate_pushdown: bool = True,
         use_zero_based: Optional[bool] = None,
+        *,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
     ) -> pl.LazyFrame:
         """
         Lazily read a PLINK 2 PGEN fileset into a LazyFrame.
 
         Projection pushdown and configured input partition parallelism are
         preserved. See `read_pgen` for the parameters.
+
+        Parameters:
+            max_companion_bytes: Maximum on-disk companion size in bytes. None uses the provider default (4 GiB).
+            max_decompressed_companion_bytes: Maximum decoded companion size in bytes. None uses the provider default (16 GiB).
+            max_variants: Maximum PVAR row count. None uses the provider default (250 million).
         """
         _validate_pgen_input_path(path)
         _validate_pgen_genotype_fields(genotype_fields)
@@ -2363,9 +2370,6 @@ class IOOperations:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
-        max_companion_bytes: Union[int, None] = None,
-        max_decompressed_companion_bytes: Union[int, None] = None,
-        max_variants: Union[int, None] = None,
         chunk_size: int = 8,
         concurrent_fetches: int = 1,
         allow_anonymous: bool = True,
@@ -2375,6 +2379,10 @@ class IOOperations:
         compression_type: str = "auto",
         use_zero_based: Optional[bool] = None,
         copy_threads: Union[int, None] = None,
+        *,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
     ) -> "PgenMatrix":
         """
         Read one genotype field of a PGEN fileset into a dense NumPy matrix.
@@ -2405,6 +2413,9 @@ class IOOperations:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads.
             max_range_bytes: The largest coalesced read, in bytes.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch.
+            max_companion_bytes: Maximum on-disk companion size in bytes. None uses the provider default (4 GiB).
+            max_decompressed_companion_bytes: Maximum decoded companion size in bytes. None uses the provider default (16 GiB).
+            max_variants: Maximum PVAR row count. None uses the provider default (250 million).
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -3296,6 +3307,7 @@ class IOOperations:
         pvar_path: Union[str, None] = None,
         psam_path: Union[str, None] = None,
         pgi_path: Union[str, None] = None,
+        *,
         max_companion_bytes: Union[int, None] = None,
         max_decompressed_companion_bytes: Union[int, None] = None,
         max_variants: Union[int, None] = None,

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -1072,6 +1072,9 @@ class SQL:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
         chunk_size: int = 64,
         concurrent_fetches: int = 8,
         allow_anonymous: bool = True,
@@ -1097,6 +1100,9 @@ class SQL:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads, in bytes. The provider default is 0, which never bridges a gap and issues one read per contiguous run of selected variants. Raising it trades wasted bytes for fewer requests, which matters most on object storage. If *None*, the provider default is used.
             max_range_bytes: The largest coalesced read, in bytes. If *None*, the provider default is used.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch. If *None*, the provider default is used.
+            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
+            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
+            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -1139,6 +1145,9 @@ class SQL:
             max_range_gap=max_range_gap,
             max_range_bytes=max_range_bytes,
             batch_soft_byte_limit=batch_soft_byte_limit,
+            max_companion_bytes=max_companion_bytes,
+            max_decompressed_companion_bytes=max_decompressed_companion_bytes,
+            max_variants=max_variants,
             zero_based=_resolve_zero_based(use_zero_based),
         )
         read_options = ReadOptions(pgen_read_options=pgen_read_options)

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -1072,9 +1072,6 @@ class SQL:
         max_range_gap: Union[int, None] = None,
         max_range_bytes: Union[int, None] = None,
         batch_soft_byte_limit: Union[int, None] = None,
-        max_companion_bytes: Union[int, None] = None,
-        max_decompressed_companion_bytes: Union[int, None] = None,
-        max_variants: Union[int, None] = None,
         chunk_size: int = 64,
         concurrent_fetches: int = 8,
         allow_anonymous: bool = True,
@@ -1083,6 +1080,10 @@ class SQL:
         enable_request_payer: bool = False,
         compression_type: str = "auto",
         use_zero_based: Optional[bool] = None,
+        *,
+        max_companion_bytes: Union[int, None] = None,
+        max_decompressed_companion_bytes: Union[int, None] = None,
+        max_variants: Union[int, None] = None,
     ) -> None:
         """
         Register a PLINK 2 PGEN fileset as a DataFusion table.

--- a/polars_bio/sql.py
+++ b/polars_bio/sql.py
@@ -1101,9 +1101,6 @@ class SQL:
             max_range_gap: The largest run of unselected bytes bridged when coalescing reads, in bytes. The provider default is 0, which never bridges a gap and issues one read per contiguous run of selected variants. Raising it trades wasted bytes for fewer requests, which matters most on object storage. If *None*, the provider default is used.
             max_range_bytes: The largest coalesced read, in bytes. If *None*, the provider default is used.
             batch_soft_byte_limit: A soft target for genotype bytes in one RecordBatch. If *None*, the provider default is used.
-            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
-            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
-            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
             chunk_size: The size in MB of a chunk when reading from an object store.
             concurrent_fetches: The number of concurrent fetches when reading from an object store.
             allow_anonymous: Whether to allow anonymous access to object storage.
@@ -1112,6 +1109,9 @@ class SQL:
             enable_request_payer: Whether to enable request payer for object storage.
             compression_type: The compression override.
             use_zero_based: If True, register 0-based half-open coordinates. If False, 1-based closed. If None (default), uses the global configuration.
+            max_companion_bytes: The largest on-disk size accepted for the `.pvar` or `.psam` companion, in bytes. The provider default is 4 GiB. Companions are streamed, so this bounds work rather than memory. If *None*, the provider default is used.
+            max_decompressed_companion_bytes: The largest decoded size accepted for a companion, in bytes. The provider default is 16 GiB. If *None*, the provider default is used.
+            max_variants: The largest PVAR row count accepted. The provider default is 250 million; the parsed variant table costs a few tens of bytes per row, so this is the cap that bounds resident memory. If *None*, the provider default is used.
 
         !!! Example
             ```python

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1379,9 +1379,18 @@ impl PyPgenMatrixReader {
         self.inner.sample_names()
     }
 
-    /// Variant start positions, in row order.
-    fn positions(&self) -> Vec<u64> {
-        self.inner.positions()
+    /// Fills `destination`, an `int64` NumPy array, with the row positions.
+    fn positions_into(&self, destination: &Bound<'_, PyAny>) -> PyResult<()> {
+        let (variants, _) = self.inner.shape();
+        let address =
+            validated_destination(destination, "int64", std::mem::align_of::<i64>(), variants)?;
+        // SAFETY: `address` came from `destination`, checked just above to hold
+        // `variants` writable, C-contiguous, aligned `int64`s, and the GIL is
+        // held for the fill, so the array cannot be resized or freed meanwhile.
+        let out = unsafe { std::slice::from_raw_parts_mut(address as *mut i64, variants) };
+        self.inner
+            .positions_into(out)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
     /// Decodes one genotype field into `destination`, a NumPy array.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1381,6 +1381,9 @@ impl PyPgenMatrixReader {
 
     /// Fills `destination`, an `int64` NumPy array, with the row positions.
     fn positions_into(&self, destination: &Bound<'_, PyAny>) -> PyResult<()> {
+        // Keep the GIL through validation and filling, just as in read_into:
+        // releasing it would let another Python thread resize destination with
+        // refcheck=False and invalidate its allocation before the final write.
         let (variants, _) = self.inner.shape();
         let address =
             validated_destination(destination, "int64", std::mem::align_of::<i64>(), variants)?;

--- a/src/option.rs
+++ b/src/option.rs
@@ -1015,12 +1015,21 @@ pub struct PgenReadOptions {
     /// Soft target for genotype bytes in one RecordBatch.
     #[pyo3(get, set)]
     pub batch_soft_byte_limit: Option<usize>,
+    /// Maximum on-disk bytes accepted for a PVAR or PSAM companion.
+    #[pyo3(get, set)]
+    pub max_companion_bytes: Option<usize>,
+    /// Maximum decoded bytes accepted for a PVAR or PSAM companion.
+    #[pyo3(get, set)]
+    pub max_decompressed_companion_bytes: Option<usize>,
+    /// Maximum accepted PVAR row count.
+    #[pyo3(get, set)]
+    pub max_variants: Option<usize>,
 }
 
 #[pymethods]
 impl PgenReadOptions {
     #[new]
-    #[pyo3(signature = (object_storage_options=None, genotype_fields=None, zero_based=false, samples=None, missing_sample_policy="error".to_string(), psam_id_mode="iid".to_string(), pvar_path=None, psam_path=None, pgi_path=None, max_range_gap=None, max_range_bytes=None, batch_soft_byte_limit=None))]
+    #[pyo3(signature = (object_storage_options=None, genotype_fields=None, zero_based=false, samples=None, missing_sample_policy="error".to_string(), psam_id_mode="iid".to_string(), pvar_path=None, psam_path=None, pgi_path=None, max_range_gap=None, max_range_bytes=None, batch_soft_byte_limit=None, max_companion_bytes=None, max_decompressed_companion_bytes=None, max_variants=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         object_storage_options: Option<PyObjectStorageOptions>,
@@ -1035,6 +1044,9 @@ impl PgenReadOptions {
         max_range_gap: Option<u64>,
         max_range_bytes: Option<u64>,
         batch_soft_byte_limit: Option<usize>,
+        max_companion_bytes: Option<usize>,
+        max_decompressed_companion_bytes: Option<usize>,
+        max_variants: Option<usize>,
     ) -> Self {
         PgenReadOptions {
             object_storage_options: pyobject_storage_options_to_object_storage_options(
@@ -1051,6 +1063,9 @@ impl PgenReadOptions {
             max_range_gap,
             max_range_bytes,
             batch_soft_byte_limit,
+            max_companion_bytes,
+            max_decompressed_companion_bytes,
+            max_variants,
         }
     }
 
@@ -1077,6 +1092,9 @@ impl PgenReadOptions {
             max_range_gap: None,
             max_range_bytes: None,
             batch_soft_byte_limit: None,
+            max_companion_bytes: None,
+            max_decompressed_companion_bytes: None,
+            max_variants: None,
         }
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1219,21 +1219,7 @@ impl OpenPgenMatrix {
                 out.len()
             )));
         }
-        let mut filled = 0;
-        for (slot, position) in out.iter_mut().zip(self.reader.positions_iter()) {
-            *slot = i64::try_from(position).map_err(|_| {
-                datafusion::error::DataFusionError::Execution(format!(
-                    "PGEN position {position} does not fit int64"
-                ))
-            })?;
-            filled += 1;
-        }
-        if filled != variants {
-            return Err(datafusion::error::DataFusionError::Execution(format!(
-                "PGEN reported {variants} variants but {filled} positions"
-            )));
-        }
-        Ok(())
+        fill_pgen_positions(self.reader.positions_iter(), out)
     }
 
     /// Decodes into memory the caller owns.
@@ -1396,6 +1382,30 @@ impl OpenBgenMatrix {
     }
 }
 
+fn fill_pgen_positions(
+    mut positions: impl Iterator<Item = u64>,
+    out: &mut [i64],
+) -> datafusion::common::Result<()> {
+    let variants = out.len();
+    for (filled, slot) in out.iter_mut().enumerate() {
+        let position = positions.next().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "PGEN reported {variants} variants but {filled} positions"
+            ))
+        })?;
+        *slot = i64::try_from(position).map_err(|_| {
+            DataFusionError::Execution(format!("PGEN position {position} does not fit int64"))
+        })?;
+    }
+    // One extra next() detects an overlong iterator without rescanning a panel.
+    if positions.next().is_some() {
+        return Err(DataFusionError::Execution(format!(
+            "PGEN reported {variants} variants but more than {variants} positions"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1404,8 +1414,40 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
 
     use super::RecordBatch;
-    use super::{get_input_format, partition_record_batches};
+    use super::{fill_pgen_positions, get_input_format, partition_record_batches};
     use crate::option::InputFormat;
+
+    #[test]
+    fn pgen_positions_enforce_exact_iterator_length() {
+        let mut out = [0; 2];
+        fill_pgen_positions([10, 20].into_iter(), &mut out).unwrap();
+        assert_eq!(out, [10, 20]);
+        let short = fill_pgen_positions([10].into_iter(), &mut out).unwrap_err();
+        assert!(short.to_string().contains("2 variants but 1 positions"));
+        let long = fill_pgen_positions([10, 20, 30].into_iter(), &mut out).unwrap_err();
+        assert!(long.to_string().contains("more than 2 positions"));
+        fill_pgen_positions(std::iter::empty(), &mut []).unwrap();
+        assert!(fill_pgen_positions(std::iter::once(10), &mut []).is_err());
+    }
+
+    #[test]
+    fn pgen_positions_reject_int64_overflow() {
+        let error = fill_pgen_positions(std::iter::once(u64::MAX), &mut [0]).unwrap_err();
+        assert!(error.to_string().contains("does not fit int64"));
+    }
+
+    #[test]
+    fn pgen_unset_caps_use_native_provider_defaults() {
+        let options = crate::option::PgenReadOptions::default();
+        let actual = super::native_pgen_options(&options).unwrap();
+        let expected = super::NativePgenReadOptions::default();
+        assert_eq!(actual.max_companion_bytes, expected.max_companion_bytes);
+        assert_eq!(
+            actual.max_decompressed_companion_bytes,
+            expected.max_decompressed_companion_bytes
+        );
+        assert_eq!(actual.max_variants, expected.max_variants);
+    }
 
     fn make_batch(start: i32, len: usize) -> RecordBatch {
         let contigs = StringArray::from_iter_values((0..len).map(|_| "chr1"));

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -552,6 +552,13 @@ pub fn native_pgen_options(
         batch_soft_byte_limit: options
             .batch_soft_byte_limit
             .unwrap_or(defaults.batch_soft_byte_limit),
+        max_companion_bytes: options
+            .max_companion_bytes
+            .unwrap_or(defaults.max_companion_bytes),
+        max_decompressed_companion_bytes: options
+            .max_decompressed_companion_bytes
+            .unwrap_or(defaults.max_decompressed_companion_bytes),
+        max_variants: options.max_variants.unwrap_or(defaults.max_variants),
         ..defaults
     })
 }
@@ -1200,9 +1207,33 @@ impl OpenPgenMatrix {
         self.reader.sample_names().to_vec()
     }
 
-    /// Variant start positions, in row order.
-    pub fn positions(&self) -> Vec<u64> {
-        self.reader.positions()
+    /// Fills `out` with the variant start positions, in row order.
+    ///
+    /// The panel-scale filesets have tens of millions of rows, so the
+    /// positions are streamed into the caller's buffer rather than collected.
+    pub fn positions_into(&self, out: &mut [i64]) -> datafusion::common::Result<()> {
+        let (variants, _) = self.shape();
+        if out.len() != variants {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "PGEN positions destination holds {} values; expected {variants}",
+                out.len()
+            )));
+        }
+        let mut filled = 0;
+        for (slot, position) in out.iter_mut().zip(self.reader.positions_iter()) {
+            *slot = i64::try_from(position).map_err(|_| {
+                datafusion::error::DataFusionError::Execution(format!(
+                    "PGEN position {position} does not fit int64"
+                ))
+            })?;
+            filled += 1;
+        }
+        if filled != variants {
+            return Err(datafusion::error::DataFusionError::Execution(format!(
+                "PGEN reported {variants} variants but {filled} positions"
+            )));
+        }
+        Ok(())
     }
 
     /// Decodes into memory the caller owns.

--- a/tests/test_pgen_io.py
+++ b/tests/test_pgen_io.py
@@ -1,5 +1,6 @@
 """PGEN read, scan, register, and describe tests."""
 
+import inspect
 import sys
 
 import numpy as np
@@ -850,6 +851,112 @@ class TestPgenMatrix:
                 assert matrix.values.shape == (3, len(ORACLE_SAMPLES))
         finally:
             pb.set_option(TARGET_PARTITIONS, previous)
+
+
+_LEGACY_SCAN_PARAMETERS = (
+    "path genotype_fields samples missing_sample_policy psam_id_mode "
+    "pvar_path psam_path pgi_path max_range_gap max_range_bytes "
+    "batch_soft_byte_limit chunk_size concurrent_fetches allow_anonymous "
+    "enable_request_payer max_retries timeout compression_type "
+    "projection_pushdown predicate_pushdown use_zero_based"
+).split()
+
+_LEGACY_PGEN_PARAMETERS = [
+    (pb.read_pgen, _LEGACY_SCAN_PARAMETERS),
+    (pb.scan_pgen, _LEGACY_SCAN_PARAMETERS),
+    (
+        pb.read_pgen_matrix,
+        (
+            "path field samples missing missing_sample_policy psam_id_mode "
+            "pvar_path psam_path pgi_path max_range_gap max_range_bytes "
+            "batch_soft_byte_limit chunk_size concurrent_fetches allow_anonymous "
+            "enable_request_payer max_retries timeout compression_type "
+            "use_zero_based copy_threads"
+        ).split(),
+    ),
+    (
+        pb.describe_pgen,
+        (
+            "path allow_anonymous enable_request_payer compression_type "
+            "pvar_path psam_path pgi_path"
+        ).split(),
+    ),
+    (
+        pb.register_pgen,
+        (
+            "path name genotype_fields samples missing_sample_policy psam_id_mode "
+            "pvar_path psam_path pgi_path max_range_gap max_range_bytes "
+            "batch_soft_byte_limit chunk_size concurrent_fetches allow_anonymous "
+            "max_retries timeout enable_request_payer compression_type use_zero_based"
+        ).split(),
+    ),
+]
+
+
+@pytest.mark.parametrize("entrypoint, legacy_names", _LEGACY_PGEN_PARAMETERS)
+def test_pgen_legacy_positional_argument_order(entrypoint, legacy_names):
+    # Keep this list independent of the current signature: deriving the order
+    # from it would allow a newly inserted argument to silently remap callers.
+    values = [object() for _ in legacy_names]
+    signature = inspect.signature(entrypoint)
+    assert signature.bind(*values).arguments == dict(zip(legacy_names, values))
+    for name in (
+        "max_companion_bytes",
+        "max_decompressed_companion_bytes",
+        "max_variants",
+    ):
+        parameter = signature.parameters[name]
+        assert parameter.kind == inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is None
+        assert f"{name}:" in entrypoint.__doc__
+
+
+@pytest.mark.parametrize("entrypoint, legacy_names", _LEGACY_PGEN_PARAMETERS)
+def test_pgen_legacy_positional_calls_match_keyword_calls(entrypoint, legacy_names):
+    signature = inspect.signature(entrypoint)
+    overrides = {
+        "path": str(ORACLE_PATH),
+        "name": "pgen_legacy_positional",
+        "samples": ["s3", "s1"],
+        "genotype_fields": ("ALT_COUNT",),
+        "field": "ALT_COUNT",
+        "chunk_size": 17,
+        "use_zero_based": True,
+        "copy_threads": 1,
+    }
+    kwargs = {
+        name: overrides.get(name, signature.parameters[name].default)
+        for name in legacy_names
+    }
+
+    def materialize(positional):
+        try:
+            result = (
+                entrypoint(*kwargs.values()) if positional else entrypoint(**kwargs)
+            )
+            if entrypoint is pb.register_pgen:
+                return pb.sql(
+                    "SELECT * FROM pgen_legacy_positional ORDER BY start"
+                ).collect()
+            if entrypoint is pb.scan_pgen:
+                return result.collect().sort("start")
+            if entrypoint is pb.read_pgen:
+                return result.sort("start")
+            return result
+        finally:
+            if entrypoint is pb.register_pgen:
+                ctx.deregister_table("pgen_legacy_positional")
+
+    actual = materialize(True)
+    expected = materialize(False)
+    if entrypoint is pb.read_pgen_matrix:
+        np.testing.assert_array_equal(actual.values, expected.values)
+        np.testing.assert_array_equal(actual.positions, expected.positions)
+        assert actual.sample_names == expected.sample_names
+    elif isinstance(actual, pl.DataFrame):
+        assert actual.equals(expected)
+    else:
+        assert actual == expected
 
 
 class TestPgenCompanionLimits:

--- a/tests/test_pgen_io.py
+++ b/tests/test_pgen_io.py
@@ -1021,9 +1021,16 @@ class TestPgenCompanionLimits:
         with pytest.raises(ValueError, match=expected):
             pb.read_pgen(str(ORACLE_PATH), **kwargs)
         with pytest.raises(ValueError, match=expected):
+            pb.scan_pgen(str(ORACLE_PATH), **kwargs).collect()
+        with pytest.raises(ValueError, match=expected):
             pb.describe_pgen(str(ORACLE_PATH), **kwargs)
         with pytest.raises(ValueError, match=expected):
             pb.read_pgen_matrix(str(ORACLE_PATH), field="ALT_COUNT", **kwargs)
+        try:
+            with pytest.raises(ValueError, match=expected):
+                pb.register_pgen(str(ORACLE_PATH), "pgen_lowered_caps", **kwargs)
+        finally:
+            ctx.deregister_table("pgen_lowered_caps")
 
     def test_a_raised_cap_does_not_change_content(self):
         raised = pb.read_pgen(str(ORACLE_PATH), **self.CAPS).sort("start")

--- a/tests/test_pgen_io.py
+++ b/tests/test_pgen_io.py
@@ -850,3 +850,90 @@ class TestPgenMatrix:
                 assert matrix.values.shape == (3, len(ORACLE_SAMPLES))
         finally:
             pb.set_option(TARGET_PARTITIONS, previous)
+
+
+class TestPgenCompanionLimits:
+    """The companion caps bound what the provider will load (#453).
+
+    The published 1000 Genomes panel is far too large to be a fixture, so
+    these tests prove the caps reach the provider and fail by name, and that a
+    raised cap changes nothing; the real panel is checked outside CI.
+    """
+
+    CAPS = {
+        "max_companion_bytes": 1 << 30,
+        "max_decompressed_companion_bytes": 1 << 31,
+        "max_variants": 12_345,
+    }
+
+    @pytest.mark.parametrize(
+        "module_name, call",
+        [
+            ("io", lambda caps: pb.read_pgen(str(ORACLE_PATH), **caps)),
+            ("io", lambda caps: pb.scan_pgen(str(ORACLE_PATH), **caps).collect()),
+            ("io", lambda caps: pb.describe_pgen(str(ORACLE_PATH), **caps)),
+            (
+                "io",
+                lambda caps: pb.read_pgen_matrix(
+                    str(ORACLE_PATH), field="ALT_COUNT", **caps
+                ),
+            ),
+            (
+                "sql",
+                lambda caps: pb.register_pgen(str(ORACLE_PATH), "pgen_caps", **caps),
+            ),
+        ],
+        ids=["read", "scan", "describe", "matrix", "register"],
+    )
+    def test_caps_reach_the_provider_options(self, module_name, call):
+        module = pb_io if module_name == "io" else pb_sql
+        seen = _captured_pgen_options(module, lambda: call(self.CAPS))
+        if module_name == "sql":
+            ctx.deregister_table("pgen_caps")
+        for name, value in self.CAPS.items():
+            assert seen[name] == value, name
+
+    def test_unset_caps_keep_the_provider_default(self):
+        seen = _captured_pgen_options(pb_io, lambda: pb.read_pgen(str(ORACLE_PATH)))
+        for name in self.CAPS:
+            assert seen[name] is None, name
+
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            ({"max_companion_bytes": 1}, "max_companion_bytes 1"),
+            (
+                {"max_decompressed_companion_bytes": 4},
+                "max_decompressed_companion_bytes 4",
+            ),
+            ({"max_variants": 1}, "max_variants 1"),
+        ],
+        ids=["companion", "decompressed", "variants"],
+    )
+    def test_a_lowered_cap_fails_by_name(self, kwargs, expected):
+        with pytest.raises(ValueError, match=expected):
+            pb.read_pgen(str(ORACLE_PATH), **kwargs)
+        with pytest.raises(ValueError, match=expected):
+            pb.describe_pgen(str(ORACLE_PATH), **kwargs)
+        with pytest.raises(ValueError, match=expected):
+            pb.read_pgen_matrix(str(ORACLE_PATH), field="ALT_COUNT", **kwargs)
+
+    def test_a_raised_cap_does_not_change_content(self):
+        raised = pb.read_pgen(str(ORACLE_PATH), **self.CAPS).sort("start")
+        default = pb.read_pgen(str(ORACLE_PATH)).sort("start")
+        assert raised.equals(default)
+        assert raised["id"].to_list() == ORACLE_IDS
+
+
+class TestPgenMatrixPositions:
+    def test_positions_are_filled_into_an_int64_array_from_rust(self):
+        from polars_bio.polars_bio import PgenMatrixReader
+
+        matrix = pb.read_pgen_matrix(str(ORACLE_PATH), field="ALT_COUNT")
+        assert matrix.positions.dtype == np.int64
+        starts = pb.read_pgen(str(ORACLE_PATH)).sort("start")["start"].to_list()
+        assert matrix.positions.tolist() == starts
+        # The reader fills a caller-owned array; a list-returning accessor would
+        # rebuild every position as a Python int first.
+        assert hasattr(PgenMatrixReader, "positions_into")
+        assert not hasattr(PgenMatrixReader, "positions")


### PR DESCRIPTION
## Summary

Fixes #453. `describe_pgen`, `scan_pgen`, `read_pgen`, and `read_pgen_matrix` refused the published PGS Catalog 1000 Genomes PLINK 2 fileset (`pgsc_1000G_v1`) because its `.pvar.zst` (541–592 MiB) exceeded a 512 MiB companion cap in the upstream provider that no polars-bio entry point could raise. Behind it sat a 1 GiB decoded cap and, for GRCh37, a 100M-variant cap the panel's 84.8M rows nearly reached.

The caps guarded an eager per-row PVAR materialization that measured at ~600 B per variant, so raising them alone would have needed ~45 GB to open the 75.2M-variant GRCh38 panel. The memory model was fixed upstream in biodatageeks/datafusion-bio-formats#247 (streamed block-parallel decode into a columnar variant table, compact scan selection, raised defaults, option names in every limit error). This PR is the polars-bio side.

## What changes

- `datafusion-bio-format-*` crates pinned to the upstream master commit `1c86f0c` carrying #247. No release tag has been cut for it yet; the `Cargo.toml` note says to move back to a tag once one exists.
- `max_companion_bytes`, `max_decompressed_companion_bytes`, and `max_variants` on `read_pgen`, `scan_pgen`, `read_pgen_matrix`, `describe_pgen`, and `register_pgen`, forwarded through `PgenReadOptions` like the existing range controls; `None` keeps the provider default (4 GiB / 16 GiB / 250M).
- `read_pgen_matrix` fills `positions` into an `int64` NumPy array from Rust (`PgenMatrixReader.positions_into`) instead of building a list of one Python integer per variant, which on the panel would have cost ~2.7 GB on its own.
- Docs (`docs/features/reading.md`), changelog, and OpenSpec change `refactor-pgen-companion-memory-model` plus two follow-up proposals (`add-pgen-matrix-variant-selection`, `add-pgen-companion-sidecar-cache`).

## Verification on the real fileset

`GRCh38_1000G_ALL.pgen` from the EBI tarball in the issue: 75,193,455 variants, 3,202 samples, 541 MiB `.pvar.zst`.

| Call | Before (0.35.1) | After |
|---|---|---|
| `describe_pgen` | `exceeding configured limit 536870912` | opens in 4.2 s |
| `scan_pgen` metadata scan, all rows | same error | 75,193,455 rows |
| `scan_pgen(genotype_fields=["ALT_COUNT"])` on chr22:16.0–16.1M | same error | 4,026 variants via pushdown |
| ALT counts vs `pgenlib` on that region | — | 0 mismatches |
| GRCh37 companions (84.8M variants) | same error | parse in 4.9 s at 3.2 GB |

Upstream open of the GRCh38 panel: 4.27 s at 3.74 GB peak RSS (release build). `read_pgen_matrix` on the whole panel still cannot complete by design: the dense output is 224 GiB; row selection is the `add-pgen-matrix-variant-selection` follow-up.

## Benchmarks

bioformats-benchmark genotype-reader workloads, one thread, medians of three fresh-process runs, both wheels built with `-C target-cpu=native`, identical dependency trees. A = master, B = this PR.

| Workload | A | B | Δ time | A peak RSS | B peak RSS |
|---|---:|---:|---:|---:|---:|
| PGEN hardcall, chr22 (993,881 variants) | 0.694 s | 0.633 s | −8.8% | 5,608 MB | 5,231 MB |
| PGEN dosage | 1.254 s | 1.228 s | −2.1% | 12,847 MB | 12,472 MB |
| BGEN dosage | 12.555 s | 12.350 s | −1.6% | 22,288 MB | 22,289 MB |
| BGEN probabilities, 25k | 1.127 s | 1.176 s | noise | 5,628 MB | 5,628 MB |
| BCF dosage, 25k | 0.173 s | 0.168 s | −2.9% | 292 MB | 292 MB |

All runner equivalence checks passed, including element-wise PGEN verification against pgenlib.

## Tests

- `tests/test_pgen_io.py`: caps reach the provider options at every entry point, unset caps keep the provider default, a lowered cap fails naming the argument, a raised cap does not change content, and positions arrive as `int64` without a list round trip.
- `tests/test_pgen_io.py` (103) and `tests/test_bgen_io.py` (57) green against the pinned commit; the pre-commit `cargo check` passes now that the upstream API is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ujSqyNzfjgTTnWEadAoVA
