### PR TITLE
fix(bed): use bio-formats v1.12.1 (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated bio-format dependencies to v1.12.1, restoring release-tag pins after
+  the BED reader and PGEN companion fixes (#457).
 - PGEN companions are streamed and parsed into a columnar variant table
   upstream (`datafusion-bio-formats`), so production PLINK 2 filesets open
   without tuning: the PGS Catalog 1000 Genomes GRCh38 panel (75.2M variants,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- BED3 files now retain every interval in eager, lazy, and SQL reads, with null
+  names for the missing fourth field. Malformed BED records raise errors instead
+  of silently disappearing (#456). The upstream fixes also cover compression,
+  empty intervals, query row counts, and HTTP sources that deny HEAD requests.
 - `describe_pgen`, `scan_pgen`, `read_pgen`, and `read_pgen_matrix` rejected
   the published 1000 Genomes PLINK 2 fileset because its `.pvar.zst` exceeded
   a hard 512 MiB companion cap that no entry point could raise (#453). The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bam"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bbi"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1566,7 +1566,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bgen"
 version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cooler"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-cram"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fasta"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-fastq"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gff"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-gtf"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pairs"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-pgen"
 version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=1c86f0c9d19ccc85eaf196508c26d70a220f21f9#1c86f0c9d19ccc85eaf196508c26d70a220f21f9"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,8 +1504,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bam"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1530,8 +1530,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bbi"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.10.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-trait",
  "bigtools",
@@ -1542,8 +1542,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1565,8 +1565,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bgen"
-version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "0.4.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1585,8 +1585,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cooler"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1600,8 +1600,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1623,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-cram"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1649,8 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fasta"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1672,8 +1672,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-fastq"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1696,8 +1696,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gff"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1723,8 +1723,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-gtf"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1747,8 +1747,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pairs"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1774,8 +1774,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-pgen"
-version = "0.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "0.4.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1793,8 +1793,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=04e2bd0859473fa889f22dcc0157344abd15da65#04e2bd0859473fa889f22dcc0157344abd15da65"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,10 @@ pyo3-log = "0.13.3"
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats
 # v1.12.0 / datafusion-bio-functions v0.19.1, which pin datafusion to "=53.0.0".
 # Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
-# datafusion-bio-formats is pinned to the master commit carrying PR #247 (PGEN
-# companion streaming, polars-bio #453). The release-tag transition is tracked
+# datafusion-bio-formats is pinned to PR #249 head for BED3 parsing and error
+# propagation (polars-bio #456), including the existing PR #247 PGEN fixes.
+# https://github.com/biodatageeks/datafusion-bio-formats/pull/249
+# The release-tag transition is tracked
 # in https://github.com/biodatageeks/polars-bio/issues/457.
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
@@ -51,20 +53,20 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
-datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "1c86f0c9d19ccc85eaf196508c26d70a220f21f9" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,10 @@ pyo3-log = "0.13.3"
 
 
 # NOTE: temporarily pinned to 53.0.0 (down from 53.1.0) to match datafusion-bio-formats
-# v1.12.0 / datafusion-bio-functions v0.19.1, which pin datafusion to "=53.0.0".
+# v1.12.1 / datafusion-bio-functions v0.19.1, which pin datafusion to "=53.0.0".
 # Restore 53.1.0 once those crates publish releases built against datafusion 53.1.0.
-# datafusion-bio-formats is pinned to PR #249 head for BED3 parsing and error
-# propagation (polars-bio #456), including the existing PR #247 PGEN fixes.
-# https://github.com/biodatageeks/datafusion-bio-formats/pull/249
-# The release-tag transition is tracked
-# in https://github.com/biodatageeks/polars-bio/issues/457.
+# datafusion-bio-formats v1.12.1 includes the BED3/error-propagation fixes
+# (#456) and PGEN companion streaming fixes (#453).
 datafusion = { version = "53.0.0", default-features = false, features = ["nested_expressions", "crypto_expressions", "datetime_expressions", "encoding_expressions", "regex_expressions", "string_expressions", "unicode_expressions", "parquet", "recursive_protection", "sql"] }
 arrow = "58.3.0"
 arrow-schema = "58.3.0"
@@ -53,20 +50,20 @@ log = "0.4.22"
 tracing = { version = "0.1.41", features = ["log"] }
 futures-util = "0.3.31"
 
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
-datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "04e2bd0859473fa889f22dcc0157344abd15da65" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-fastq = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-bam = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-cram = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-fasta = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-pairs = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-gtf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-bbi = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-bgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-pgen = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+datafusion-bio-format-cooler = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 
 datafusion-bio-function-ranges = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1" }
 datafusion-bio-function-pileup = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.19.1", default-features = false }

--- a/tests/test_bed_regressions.py
+++ b/tests/test_bed_regressions.py
@@ -1,0 +1,125 @@
+"""Public reader regressions for BED3 row loss and swallowed errors (#456)."""
+
+import gzip
+
+import polars as pl
+import pysam
+import pytest
+
+import polars_bio as pb
+
+ROWS = [("chr1", 0, 5), ("chr1", 4, 8), ("chr1", 21, 29)]
+
+
+@pytest.fixture(params=["plain", "gzip", "bgzf"])
+def bed_file(tmp_path, request):
+    def write(content):
+        path = tmp_path / "records.bed"
+        path.write_bytes(content)
+        if request.param == "gzip":
+            path = tmp_path / "records.bed.gz"
+            path.write_bytes(gzip.compress(content))
+        elif request.param == "bgzf":
+            compressed = tmp_path / "records.bed.bgz"
+            pysam.tabix_compress(str(path), str(compressed), force=True)
+            path = compressed
+        return str(path)
+
+    return write
+
+
+@pytest.fixture(params=["read", "scan", "sql"])
+def read_bed(request):
+    def collect(path):
+        if request.param == "read":
+            return pb.read_bed(path, use_zero_based=True)
+        if request.param == "scan":
+            return pb.scan_bed(path, use_zero_based=True).collect()
+        pb.register_bed(path, "bed_regression")
+        return pb.sql("SELECT * FROM bed_regression").collect()
+
+    return collect
+
+
+@pytest.mark.parametrize("width", range(3, 13), ids=lambda width: f"BED{width}")
+def test_bed3_to_bed12_preserve_rows(bed_file, read_bed, width):
+    lines = []
+    for index, (chrom, start, end) in enumerate(ROWS, 1):
+        fields = [
+            chrom,
+            start,
+            end,
+            f"r{index}",
+            0,
+            "+",
+            start,
+            end,
+            0,
+            1,
+            end - start,
+            0,
+        ]
+        lines.append("\t".join(map(str, fields[:width])))
+    frame = read_bed(bed_file(("\n".join(lines) + "\n").encode()))
+    assert frame.columns == ["chrom", "start", "end", "name"]
+    assert frame.select("chrom", "start", "end").rows() == ROWS
+    assert frame["name"].to_list() == ([None] * 3 if width == 3 else ["r1", "r2", "r3"])
+
+
+@pytest.mark.parametrize("ending", ["\n", "\r\n", ""])
+def test_bed3_line_endings_preserve_all_rows(bed_file, read_bed, ending):
+    separator = ending or "\n"
+    content = separator.join("\t".join(map(str, row)) for row in ROWS) + ending
+    frame = read_bed(bed_file(content.encode()))
+    assert frame.select("chrom", "start", "end").rows() == ROWS
+    assert frame["name"].null_count() == 3
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"chr1\t4\n",
+        b"chr1\t0\t5\tr1\nchr1\t4\nchr1\t21\t29\tr3\n",
+        b"chr1\t0\tbad\n",
+        b"chr1\t0\t5\t\xff\n",
+    ],
+)
+def test_malformed_records_raise_instead_of_disappearing(bed_file, read_bed, content):
+    with pytest.raises(Exception, match="BED"):
+        read_bed(bed_file(content))
+
+
+@pytest.mark.parametrize("suffix, name", [("", None), ("\t.", None), ("\t", "")])
+def test_missing_dot_and_empty_names(bed_file, read_bed, suffix, name):
+    frame = read_bed(bed_file(f"chr1\t0\t5{suffix}\n".encode()))
+    assert frame.rows() == [("chr1", 0, 5, name)]
+
+
+@pytest.mark.parametrize("content", [b"", b"# comment\n\n"])
+def test_empty_inputs_return_zero_rows(bed_file, read_bed, content):
+    assert read_bed(bed_file(content)).height == 0
+
+
+def test_bed3_count_and_projection(bed_file):
+    path = bed_file(b"chr1\t0\t5\nchr1\t4\t8\nchr1\t21\t29\n")
+    lazy = pb.scan_bed(path, use_zero_based=True)
+    assert lazy.select(pl.len()).collect().item() == 3
+    assert lazy.select("end", "name").collect().rows() == [
+        (5, None),
+        (8, None),
+        (29, None),
+    ]
+    pb.register_bed(path, "bed_count_regression")
+    assert pb.sql("SELECT COUNT(*) FROM bed_count_regression").collect().item() == 3
+
+
+@pytest.mark.parametrize("zero_based", [True, False])
+@pytest.mark.parametrize("lazy", [True, False])
+def test_bed3_empty_intervals_in_both_coordinate_systems(bed_file, zero_based, lazy):
+    path = bed_file(b"chr1\t0\t0\nchr1\t5\t5\n")
+    if lazy:
+        frame = pb.scan_bed(path, use_zero_based=zero_based).collect()
+    else:
+        frame = pb.read_bed(path, use_zero_based=zero_based)
+    offset = int(not zero_based)
+    assert frame.select("start", "end").rows() == [(offset, 0), (5 + offset, 5)]


### PR DESCRIPTION
BED3 files returned zero rows through `read_bed`, `scan_bed`, and SQL because the upstream reader required a fourth field and discarded parse failures. Update all 14 bio-format dependencies to the published [v1.12.1 release](https://github.com/biodatageeks/datafusion-bio-formats/releases/tag/v1.12.1), which includes the BED reader fixes from biodatageeks/datafusion-bio-formats#249 and the existing PGEN companion fixes from biodatageeks/datafusion-bio-formats#247.

The manifest uses the release tag, and Cargo.lock resolves all 14 format crates to release commit `419be98562b3fdbebbfdbd5a236205247ec56a67`. Cargo metadata confirms there are no local path overrides. The release restores the release-tag dependency policy tracked in #457; DataFusion remains at the compatible 53.0.0 version.

Added 213 Python regression cases covering BED3–BED12, plain/gzip/BGZF input, eager/lazy/SQL reads, line endings, missing/dot/empty names, malformed input, empty files, counts/projections, and both coordinate systems. Updated the changelog.

Validation on a fresh wheel built with `--locked` against v1.12.1, Python 3.11.13 / Polars 1.44.1 / macOS arm64:

- 430 Python tests passed across BED, PGEN, BGEN, FASTQ, FASTA, GFF, and pairs. This includes all 224 BED tests and all 113 PGEN integration tests.
- `cargo test --locked --lib`: all 19 Rust unit tests passed.
- Original 180-case reproducer passed: 144 valid-input cases retain their expected rows and coordinates; all 36 malformed-input cases raise exceptions. The reported BED3 input returns all 3 rows through eager and lazy reads, where published polars-bio 0.35.1 returned 0.
- `maturin build --release --locked`, Cargo metadata verification, formatting, and `git diff --check`: passed.
- The [upstream release workflow](https://github.com/biodatageeks/datafusion-bio-formats/actions/runs/33977436076) passed its build, tests, Clippy, and documentation checks before publishing the tag.

Fixes #456.
Fixes #457.
